### PR TITLE
Release 2.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.iml
 .gradle
+.kotlin/
 /local.properties
 /.idea/caches
 /.idea/libraries

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Phylax makes your self-hosted Frigate NVR feel like a proper mobile app.
 - **Mute cameras or groups on the fly.** Tap the bell in the toolbar to silence noisy cameras or whole zones without diving into Settings.
 - **Secure by default.** Supports client certificates (mTLS) for Cloudflare Access / nginx setups, self-signed certs on LAN.
 - **Two-way talk** on doorbell and intercom cameras, with the phone's call-quality audio path engaged for clearer voice.
+- **Guided first-run setup.** Add your Frigate server in a couple of taps; runtime permissions are requested only when a feature needs them.
+- **Fullscreen and landscape viewing.** Open a camera edge-to-edge (notch-aware), with more of the screen given to video in landscape.
 
 ## Screenshots
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,8 +38,8 @@ android {
         applicationId = "com.asksakis.freegate"
         minSdk = 29
         targetSdk = 35
-        versionCode = 15
-        versionName = "2.7"
+        versionCode = 16
+        versionName = "2.8"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/asksakis/freegate/MainActivity.kt
+++ b/app/src/main/java/com/asksakis/freegate/MainActivity.kt
@@ -274,16 +274,6 @@ class MainActivity : AppCompatActivity(),
     }
     
     /**
-     * Check if we have the required permissions based on Android version
-     */
-    private fun hasRequiredPermissions(): Boolean {
-        return ContextCompat.checkSelfPermission(
-            this,
-            Manifest.permission.ACCESS_FINE_LOCATION,
-        ) == PackageManager.PERMISSION_GRANTED
-    }
-    
-    /**
      * Log the status of all permissions needed for WiFi detection
      * This helps with debugging permission issues
      */

--- a/app/src/main/java/com/asksakis/freegate/MainActivity.kt
+++ b/app/src/main/java/com/asksakis/freegate/MainActivity.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.content.res.Configuration
 import android.graphics.Color
 import android.net.ConnectivityManager
 import android.net.Network
@@ -23,6 +24,8 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.core.view.GravityCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination
@@ -166,6 +169,47 @@ class MainActivity : AppCompatActivity(),
 
         // Edge-to-edge bottom inset for the WebView area.
         applyBottomSystemBarPadding()
+
+        // Landscape is viewing mode: drop our chrome for a bigger picture.
+        applyLandscapeChrome()
+    }
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        // Activity declares configChanges=orientation, so it is not recreated on
+        // rotation; re-apply the landscape/portrait chrome here.
+        applyLandscapeChrome()
+    }
+
+    /**
+     * In landscape we treat the app as a viewer and hide our own chrome (the status
+     * bar and the toolbar) so the WebView gets the full height; portrait restores it.
+     * Settings/mute stay reachable by rotating back to portrait, and a swipe from the
+     * top edge transiently reveals the status bar. Skipped while an in-page video
+     * fullscreen is active - that path manages the bars itself.
+     */
+    private fun applyLandscapeChrome() {
+        if (!::binding.isInitialized) return
+        val landscape = resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+        val controller = WindowInsetsControllerCompat(window, binding.root)
+        val navHost = findViewById<View>(R.id.nav_host_fragment_content_main)
+        val lp = navHost?.layoutParams as? androidx.coordinatorlayout.widget.CoordinatorLayout.LayoutParams
+        if (landscape) {
+            controller.systemBarsBehavior =
+                WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+            controller.hide(WindowInsetsCompat.Type.statusBars())
+            binding.appBarLayout.visibility = View.GONE
+            // Drop the scrolling-view behavior so the WebView lays out from the top of
+            // the CoordinatorLayout. Just GONE-ing the AppBarLayout leaves the behavior
+            // holding the old toolbar-height offset, which showed as a blank top strip.
+            lp?.behavior = null
+        } else {
+            controller.show(WindowInsetsCompat.Type.statusBars())
+            binding.appBarLayout.visibility = View.VISIBLE
+            lp?.behavior = com.google.android.material.appbar.AppBarLayout.ScrollingViewBehavior()
+        }
+        if (lp != null) navHost.layoutParams = lp
+        binding.appBarMain.requestLayout()
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
@@ -586,10 +630,13 @@ class MainActivity : AppCompatActivity(),
         val extraGap = (resources.displayMetrics.density * EXTRA_BOTTOM_GAP_DP).toInt()
         androidx.core.view.ViewCompat.setOnApplyWindowInsetsListener(container) { view, insets ->
             val bars = insets.getInsets(androidx.core.view.WindowInsetsCompat.Type.systemBars())
+            // Inset the sides by the display cutout so a landscape side punch-hole
+            // does not sit over Frigate's own left/right controls.
+            val cutout = insets.getInsets(androidx.core.view.WindowInsetsCompat.Type.displayCutout())
             view.setPadding(
-                view.paddingLeft,
+                cutout.left,
                 view.paddingTop,
-                view.paddingRight,
+                cutout.right,
                 bars.bottom + extraGap,
             )
             insets

--- a/app/src/main/java/com/asksakis/freegate/MainActivity.kt
+++ b/app/src/main/java/com/asksakis/freegate/MainActivity.kt
@@ -19,7 +19,6 @@ import android.view.View
 import android.widget.TextView
 import androidx.activity.SystemBarStyle
 import androidx.activity.enableEdgeToEdge
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
@@ -40,7 +39,6 @@ import com.asksakis.freegate.databinding.ActivityMainBinding
 import com.asksakis.freegate.utils.NetworkUtils
 import com.asksakis.freegate.utils.UpdateChecker
 import com.google.android.material.navigation.NavigationView
-import android.widget.Toast
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.launch
 
@@ -92,36 +90,6 @@ class MainActivity : AppCompatActivity(),
     private val statusHeartbeatHandler by lazy { android.os.Handler(mainLooper) }
     private var statusHeartbeatRunnable: Runnable? = null
     
-    private val requestRuntimePermissions = registerForActivityResult(
-        ActivityResultContracts.RequestMultiplePermissions()
-    ) { results ->
-        // The auto URL-switch hinges on reading the current SSID, which on every
-        // supported Android version requires ACCESS_FINE_LOCATION at runtime.
-        // (See AndroidManifest.xml for why NEARBY_WIFI_DEVICES doesn't suffice
-        // even on API 33+.)
-        val wifiKey = Manifest.permission.ACCESS_FINE_LOCATION
-        // Only reason about WiFi state if WiFi was actually in this request batch.
-        // Earlier we collapsed "wifi key missing" to "wifi denied" and showed a
-        // misleading snackbar when the user only rejected an unrelated permission
-        // (notifications, mic, etc.).
-        val wifiInResult = results.containsKey(wifiKey)
-        if (!wifiInResult) return@registerForActivityResult
-
-        val wifiGranted = results[wifiKey] == true
-
-        if (wifiGranted) {
-            networkUtils.checkAndUpdateUrl()
-            if (::navController.isInitialized &&
-                navController.currentDestination?.id == R.id.nav_home) {
-                navController.navigate(R.id.nav_home, null, fadeNavOptions)
-            }
-        }
-        // Denial path is intentionally silent. The pre-prompt rationale dialog
-        // (see showPermissionRationale) already explains what each permission
-        // does; stacking a Snackbar on top of the system "Don't allow" feedback
-        // was nagging the user about a choice they just made.
-    }
-
     override fun onCreate(savedInstanceState: Bundle?) {
         // Draw app content behind transparent system bars. The AppBarLayout carries
         // fitsSystemWindows=true so it grows under the status bar; light status icons
@@ -146,20 +114,11 @@ class MainActivity : AppCompatActivity(),
 
         val prefs = PreferenceManager.getDefaultSharedPreferences(this)
 
-        // Check if this is the first run
-        val isFirstRun = prefs.getBoolean("is_first_run", true)
-        if (isFirstRun) {
-            // Show a toast prompting the user to configure URLs
-            Toast.makeText(
-                this,
-                "Welcome! Configure Frigate URLs in Settings.",
-                Toast.LENGTH_LONG
-            ).show()
-            
-            // Save that we've shown the first-run message
-            prefs.edit().putBoolean("is_first_run", false).apply()
-        }
-        
+        // First-run guidance is handled by the Home setup empty state (shown when no
+        // usable server is configured), not a toast. The old "Welcome! Configure
+        // Frigate URLs in Settings" toast fired before the user could act and pointed
+        // at an unsignposted Settings screen, so it was removed.
+
         // Initialize network utilities (singleton)
         networkUtils = NetworkUtils.getInstance(this)
         
@@ -184,16 +143,15 @@ class MainActivity : AppCompatActivity(),
         
         // Log current permission status
         logPermissionStatus()
-        
-        // Always force-check permissions on each startup
-        // This is critical for WiFi detection to work
-        requestRequiredPermissions()
-        
-        
-        // No bottom Snackbar nag here — the rationale dialog inside
-        // requestRequiredPermissions() already does the "why we need this"
-        // explanation. Stacking two prompts (dialog + Snackbar) was the user's
-        // complaint about seeing "two notifications" at launch.
+
+        // Runtime permissions are no longer requested at launch. Each one is asked
+        // for at its feature boundary, when the user first needs it:
+        //   - Microphone: on the first two-way-talk tap (HomeFragment).
+        //   - Notifications: when the user enables alerts (NotificationsSettingsFragment).
+        //   - Location (SSID): when the user turns on Wi-Fi URL auto-switching
+        //     (ConnectionSettingsFragment).
+        // A fresh install now opens straight into the setup empty state with zero
+        // system prompts stacked in front of it.
 
         bindNavControllerIfReady()
         if (!::navController.isInitialized) {
@@ -229,6 +187,8 @@ class MainActivity : AppCompatActivity(),
             R.id.nav_settings_notifications,
             R.id.nav_settings_downloads,
             R.id.nav_settings_advanced,
+            // Setup screen: hide the gear/bell too, it owns the whole screen.
+            R.id.nav_setup,
         )
         menu.findItem(R.id.action_settings)?.isVisible = !inSettings
 
@@ -268,97 +228,6 @@ class MainActivity : AppCompatActivity(),
             else -> super.onOptionsItemSelected(item)
         }
     }
-    
-    /**
-     * Per-permission rationale strings shown in the pre-request dialog. Keyed
-     * by `Manifest.permission.*` so we can label each one with both a short
-     * title and a one-line explanation of *why* the app is asking. Without
-     * this, Android's stock prompt only shows the generic permission name and
-     * the user has no idea why Phylax needs e.g. Location.
-     */
-    private val permissionRationales = mapOf(
-        Manifest.permission.ACCESS_FINE_LOCATION to (
-            "Location"
-                to "Used only to read your current Wi-Fi network name so Phylax can switch " +
-                "between the local and remote Frigate URLs automatically. No GPS, no tracking."
-            ),
-        Manifest.permission.RECORD_AUDIO to (
-            "Microphone"
-                to "Required for two-way talk on doorbell and intercom cameras."
-            ),
-        Manifest.permission.POST_NOTIFICATIONS to (
-            "Notifications"
-                to "So Phylax can alert you when your cameras detect motion."
-            ),
-    )
-
-    /**
-     * Show a single rationale card listing every permission the app is about to
-     * ask for and why. Tapping Continue chains into the system prompts. Tapping
-     * Skip lets the user proceed without granting — the app degrades gracefully
-     * (no auto-switch / no two-way audio / no alerts) per missing permission.
-     */
-    private fun showPermissionRationale(missing: List<String>, onContinue: () -> Unit) {
-        val body = buildString {
-            missing.forEachIndexed { index, perm ->
-                val (label, why) = permissionRationales[perm]
-                    ?: ("Required permission" to "Phylax needs this permission to work properly.")
-                if (index > 0) append("\n\n")
-                append("• ").append(label).append('\n').append(why)
-            }
-        }
-        com.asksakis.freegate.ui.FreegateDialogs.builder(this)
-            .setIcon(R.mipmap.ic_launcher)
-            .setTitle("Phylax needs a few permissions")
-            .setMessage(body)
-            .setPositiveButton("Continue") { _, _ -> onContinue() }
-            .setNegativeButton("Skip") { _, _ -> }
-            .setCancelable(false)
-            .show()
-    }
-
-    /**
-     * Request the runtime permissions needed for the WiFi auto-switch +
-     * notification + two-way audio flows. ACCESS_FINE_LOCATION is mandatory
-     * across all supported API levels for unredacted SSID reads.
-     */
-    private fun requestRequiredPermissions() {
-        // Only request dangerous permissions at runtime. Normal permissions
-        // (ACCESS_WIFI_STATE, ACCESS_NETWORK_STATE, MODIFY_AUDIO_SETTINGS) are
-        // granted automatically at install time from the manifest.
-        val runtimePermissions = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            arrayOf(
-                // Required on every Android version we support to unredact the
-                // SSID for the in-home vs external URL auto-switch. NEARBY_WIFI_DEVICES
-                // doesn't substitute on API 33+ — see AndroidManifest.xml comments.
-                Manifest.permission.ACCESS_FINE_LOCATION,
-                Manifest.permission.RECORD_AUDIO,         // WebRTC mic for Frigate two-way audio
-                Manifest.permission.POST_NOTIFICATIONS    // Required to show Frigate alerts
-            )
-        } else {
-            arrayOf(
-                Manifest.permission.ACCESS_FINE_LOCATION,
-                Manifest.permission.ACCESS_COARSE_LOCATION,
-                Manifest.permission.RECORD_AUDIO
-            )
-        }
-
-        val missing = runtimePermissions.filter {
-            ContextCompat.checkSelfPermission(this, it) != PackageManager.PERMISSION_GRANTED
-        }
-        if (missing.isEmpty()) return
-
-        Log.d("MainActivity", "Requesting runtime permissions: $missing")
-        // Surface a single rationale card up front so the user sees *why* each
-        // permission is being asked for. Falling through to the bare system
-        // prompts (which only show the permission name) is bad UX — half the
-        // existing #11 / #issue reports come from users who deny Location not
-        // realising the auto Wi-Fi switch needs it.
-        showPermissionRationale(missing) {
-            requestRuntimePermissions.launch(missing.toTypedArray())
-        }
-    }
-    
     
     /**
      * Check if we have the required permissions based on Android version
@@ -633,6 +502,14 @@ class MainActivity : AppCompatActivity(),
     private fun refreshConnectionStatus() {
         val badge = connectionStatusIndicator ?: return
         val status = networkUtils.urlValidationStatus.value?.status
+        // No server configured: there's nothing to report reachability for, and the
+        // Home setup empty state already owns the screen. Hide the badge rather than
+        // show misleading "checking" bars.
+        if (status == NetworkUtils.ValidationStatus.UNCONFIGURED) {
+            badge.visibility = android.view.View.GONE
+            return
+        }
+        badge.visibility = android.view.View.VISIBLE
         val isFailed = status == NetworkUtils.ValidationStatus.FAILED ||
             status == NetworkUtils.ValidationStatus.TIMEOUT
         if (isFailed) {

--- a/app/src/main/java/com/asksakis/freegate/auth/ServerProfile.kt
+++ b/app/src/main/java/com/asksakis/freegate/auth/ServerProfile.kt
@@ -45,6 +45,16 @@ data class ServerProfile(
     val listeningSinceMs: Long = 0L,
 ) {
 
+    /**
+     * True when this profile carries at least one URL that looks like a real
+     * endpoint (http/https with a host). An "unusable" profile is the empty
+     * placeholder a fresh install starts with: the app treats it as "no server
+     * configured yet" rather than a connection failure, so networking stays idle
+     * and the Home screen shows the setup empty state instead of a broken viewer.
+     */
+    val isUsable: Boolean
+        get() = looksLikeEndpoint(internalUrl) || looksLikeEndpoint(externalUrl)
+
     fun toJson(): JSONObject = JSONObject().apply {
         put("id", id)
         put("name", name)
@@ -89,6 +99,21 @@ data class ServerProfile(
             cooldownCameraSec = json.optString("notify_cooldown_camera", "0"),
             listeningSinceMs = json.optLong("notify_listening_since_ms", 0L),
         )
+
+        /**
+         * Cheap structural check: is [url] a non-blank http/https URL with a host?
+         * This is a "did the user configure something" gate, not a reachability
+         * test - NetworkUtils still validates the endpoint over the wire before use.
+         */
+        fun looksLikeEndpoint(url: String?): Boolean {
+            val u = url?.trim().orEmpty()
+            if (u.isEmpty()) return false
+            val lower = u.lowercase()
+            if (!lower.startsWith("http://") && !lower.startsWith("https://")) return false
+            // Something must follow the scheme (a host), not just "https://".
+            val afterScheme = u.substringAfter("://", "")
+            return afterScheme.isNotBlank()
+        }
 
         private fun jsonArrayToSet(arr: JSONArray?): Set<String> {
             if (arr == null) return emptySet()

--- a/app/src/main/java/com/asksakis/freegate/auth/ServerProfileStore.kt
+++ b/app/src/main/java/com/asksakis/freegate/auth/ServerProfileStore.kt
@@ -65,6 +65,21 @@ class ServerProfileStore private constructor(context: Context) {
     fun getActive(): ServerProfile? = getActiveId()?.let { id -> readProfiles().firstOrNull { it.id == id } }
 
     /**
+     * True when the active profile carries a real endpoint. When false the app is
+     * "unconfigured": networking must stay idle and the Home screen shows the setup
+     * empty state. Reads live flat state first so a URL the user just entered (but
+     * hasn't triggered a snapshot for) still counts.
+     */
+    fun hasUsableServer(): Boolean {
+        val flatInternal = defaultPrefs.getString("internal_url", null)
+        val flatExternal = defaultPrefs.getString("external_url", null)
+        if (ServerProfile.looksLikeEndpoint(flatInternal) ||
+            ServerProfile.looksLikeEndpoint(flatExternal)
+        ) return true
+        return getActive()?.isUsable == true
+    }
+
+    /**
      * Create a new empty profile. The new profile is NOT made active — caller does
      * that via [setActive] after the user confirms.
      */
@@ -85,21 +100,45 @@ class ServerProfileStore private constructor(context: Context) {
     }
 
     /**
-     * Delete a profile. Fails when:
-     *  - The profile doesn't exist.
-     *  - It's the only profile left (must keep at least one).
+     * Delete a profile. Fails only when the profile doesn't exist. Deleting the
+     * last profile is allowed and drops the app into the unconfigured state (no
+     * active id, flat URL state cleared) so Home shows the setup empty screen -
+     * this is how "remove your only server" reaches a clean first-run-like state
+     * rather than being blocked.
      */
     fun delete(id: String): Boolean {
         val list = readProfiles().toMutableList()
-        if (list.size <= 1) return false
         val removed = list.removeIf { it.id == id }
         if (!removed) return false
         writeProfiles(list)
         if (getActiveId() == id) {
-            // Active was deleted — switch to the first remaining profile.
-            setActive(list.first().id)
+            if (list.isEmpty()) {
+                // Last server gone: clear the active pointer and wipe the flat
+                // endpoint keys so NetworkUtils reports "unconfigured" instead of
+                // retrying the deleted server's stale URLs.
+                clearActive()
+            } else {
+                // Active was deleted - switch to the first remaining profile.
+                setActive(list.first().id)
+            }
         }
         return true
+    }
+
+    /**
+     * Drop into the unconfigured state: forget the active id and clear the flat
+     * endpoint keys the connection layer reads. Credentials are cleared too so a
+     * deleted server's password can't leak into the next one added.
+     */
+    private fun clearActive() {
+        defaultPrefs.edit()
+            .remove(KEY_ACTIVE_ID)
+            .remove("internal_url")
+            .remove("external_url")
+            .commit()
+        val creds = CredentialsStore.getInstance(appContext)
+        creds.setUsername(null)
+        creds.setPassword(null)
     }
 
     /**
@@ -175,19 +214,75 @@ class ServerProfileStore private constructor(context: Context) {
     }
 
     /**
-     * One-time migration on first launch after upgrading to multi-server. If no
-     * profiles exist:
-     *   - Flat state has data → create a "Default" profile from it.
-     *   - Flat state empty → create an empty "Default" profile so the rest of
-     *     the app always has an active server to write into.
+     * One-time migration on first launch after upgrading to multi-server, and
+     * cleanup of the empty placeholder older builds used to create.
+     *
+     *   - Profiles already exist: if the ONLY profile is the auto-created empty
+     *     "Default" (no usable URL), remove it so clean-install users land in the
+     *     unconfigured state (Home setup empty screen) instead of a phantom server
+     *     that never connects. Otherwise leave the list untouched.
+     *   - No profiles, flat state has a usable URL: synthesise a "Default" from it.
+     *   - No profiles, flat state empty: do nothing. The app stays unconfigured;
+     *     the setup screen creates the first profile when the user adds a server.
      */
     fun ensureMigrated() {
-        if (readProfiles().isNotEmpty() && getActiveId() != null) return
+        val profiles = readProfiles()
+        if (profiles.isNotEmpty()) {
+            val onlyEmptyDefault = profiles.size == 1 &&
+                profiles[0].name == "Default" &&
+                !profiles[0].isUsable
+            if (onlyEmptyDefault) {
+                Log.d(TAG, "Removing empty auto-created Default profile (unconfigured state)")
+                writeProfiles(emptyList())
+                clearActive()
+            }
+            return
+        }
+        // No profiles yet. Only migrate when flat state actually holds an endpoint.
+        val hasFlatUrls = ServerProfile.looksLikeEndpoint(defaultPrefs.getString("internal_url", null)) ||
+            ServerProfile.looksLikeEndpoint(defaultPrefs.getString("external_url", null))
+        if (!hasFlatUrls) {
+            Log.d(TAG, "No profiles and no flat URLs - staying unconfigured")
+            return
+        }
         Log.d(TAG, "Migrating flat state into a server profile")
         val id = UUID.randomUUID().toString()
         val profile = snapshotFlatState(id, "Default")
         writeProfiles(listOf(profile))
         defaultPrefs.edit().putString(KEY_ACTIVE_ID, id).apply()
+    }
+
+    /**
+     * Create a fully-populated profile from a completed setup form, make it active,
+     * and mirror it into flat state so NetworkUtils can start. Returns the new id.
+     * Used by the first-run setup screen.
+     */
+    fun createAndActivate(
+        name: String,
+        internalUrl: String?,
+        externalUrl: String?,
+        username: String? = null,
+        password: String? = null,
+    ): String {
+        val id = UUID.randomUUID().toString()
+        val profile = ServerProfile(
+            id = id,
+            name = name.trim().ifBlank { "Default" },
+            internalUrl = internalUrl?.trim().orEmptyToNull(),
+            externalUrl = externalUrl?.trim().orEmptyToNull(),
+            username = username?.ifBlank { null },
+            password = password?.ifBlank { null },
+        )
+        val list = readProfiles().toMutableList().apply { add(profile) }
+        writeProfiles(list)
+        // Mirror the new profile into the flat keys the connection layer reads, then
+        // commit the active id (synchronously, so a crash can't leave the id pointing
+        // at a profile the flat state doesn't match). No cache invalidation is needed:
+        // this only runs from the unconfigured state, so there is no stale OkHttp/auth
+        // session to clear. The caller then invokes NetworkUtils.start() to go live.
+        applyToFlatState(profile)
+        defaultPrefs.edit().putString(KEY_ACTIVE_ID, id).commit()
+        return id
     }
 
     /** Build a profile snapshot from the current flat-pref state. */

--- a/app/src/main/java/com/asksakis/freegate/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/asksakis/freegate/ui/home/HomeFragment.kt
@@ -38,6 +38,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.launch
 import androidx.preference.PreferenceManager
+import androidx.navigation.fragment.findNavController
 import com.asksakis.freegate.R
 import com.asksakis.freegate.databinding.FragmentHomeBinding
 import com.asksakis.freegate.download.DownloadHandler
@@ -54,6 +55,18 @@ class HomeFragment : Fragment() {
     private lateinit var homeViewModel: HomeViewModel
     private lateinit var networkUtils: NetworkUtils
     private lateinit var fileChooserLauncher: ActivityResultLauncher<Intent>
+
+    /** Lazy RECORD_AUDIO request, fired the first time the page asks for the mic. */
+    private lateinit var micPermissionLauncher: ActivityResultLauncher<String>
+
+    /** POST_NOTIFICATIONS request for the one-time post-setup "enable alerts" offer. */
+    private lateinit var notifPermissionLauncher: ActivityResultLauncher<String>
+
+    /**
+     * The WebView audio-capture request we deferred while asking the user for
+     * RECORD_AUDIO. Granted or denied once [micPermissionLauncher] returns.
+     */
+    private var pendingAudioRequest: PermissionRequest? = null
 
     private var fileUploadCallback: ValueCallback<Array<Uri>>? = null
     private var currentLoadedUrl: String? = null
@@ -191,11 +204,16 @@ class HomeFragment : Fragment() {
         val profileStore = com.asksakis.freegate.auth.ServerProfileStore.getInstance(requireContext())
         lastSeenActiveProfileId = profileStore.getActiveId()
 
-        // Show the Connecting overlay from the very first frame so the user
-        // never sees the raw empty WebView while we resolve the URL, run
+        // First frame: if no server is configured yet, show the setup empty state
+        // (this is the first-run signpost). Otherwise show the Connecting overlay so
+        // the user never sees the raw empty WebView while we resolve the URL, run
         // network validation, log in, and render the first page. onPageFinished
-        // hides it once a real page (not about:blank / chrome-error) lands.
-        showConnectingOverlay(profileStore.getActive()?.name)
+        // hides the overlay once a real page (not about:blank / chrome-error) lands.
+        if (profileStore.hasUsableServer()) {
+            showConnectingOverlay(profileStore.getActive()?.name)
+        } else {
+            showSetupEmptyState()
+        }
 
         setupWebView()
         setupFileChooserLauncher()
@@ -320,6 +338,123 @@ class HomeFragment : Fragment() {
 
     private fun hideConnectingOverlay() {
         _binding?.connectingOverlay?.visibility = View.GONE
+    }
+
+    /**
+     * Show the first-run setup empty state over everything. Also drops the connecting
+     * overlay so we never stack a spinner behind the setup card. Buttons are wired
+     * here (idempotent): "Add server" opens the setup screen, "Setup help" opens the
+     * project docs in the browser.
+     */
+    private fun showSetupEmptyState() {
+        val binding = _binding ?: return
+        hideConnectingOverlay()
+        binding.setupAddServer.setOnClickListener {
+            findNavController().navigate(R.id.action_home_to_setup)
+        }
+        binding.setupDocs.setOnClickListener {
+            runCatching {
+                startActivity(
+                    android.content.Intent(
+                        android.content.Intent.ACTION_VIEW,
+                        android.net.Uri.parse(getString(R.string.setup_docs_url)),
+                    ),
+                )
+            }.onFailure { Log.w(TAG, "No browser to open setup docs: ${it.message}") }
+        }
+        binding.setupEmptyState.visibility = View.VISIBLE
+        binding.setupEmptyState.bringToFront()
+    }
+
+    private fun hideSetupEmptyState() {
+        _binding?.setupEmptyState?.visibility = View.GONE
+    }
+
+    /**
+     * One-time, opt-in notification offer shown after the first successful connection
+     * to a just-added server (armed by [SetupFragment]). Consumed exactly once and
+     * only when notifications are still off, so it never nags existing users or repeats.
+     */
+    private fun maybeOfferNotifications() {
+        if (!isAdded) return
+        val prefs = PreferenceManager.getDefaultSharedPreferences(requireContext())
+        if (!prefs.getBoolean(com.asksakis.freegate.ui.setup.SetupFragment.PREF_PENDING_NOTIF_OFFER, false)) return
+        // Consume the flag up front so a second SUCCESS (revalidation) can't re-show it.
+        prefs.edit().remove(com.asksakis.freegate.ui.setup.SetupFragment.PREF_PENDING_NOTIF_OFFER).apply()
+        if (prefs.getBoolean("notifications_enabled", false)) return
+
+        com.asksakis.freegate.ui.FreegateDialogs.builder(requireContext())
+            .setTitle("Enable notifications?")
+            .setMessage(
+                "Get a notification when this server reports an Alert (higher-confidence " +
+                    "events like a person or car). You can fine-tune Alerts vs Detections, " +
+                    "cameras and zones later in Settings > Notifications."
+            )
+            .setPositiveButton("Enable") { _, _ ->
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+                    ContextCompat.checkSelfPermission(
+                        requireContext(), Manifest.permission.POST_NOTIFICATIONS,
+                    ) != PackageManager.PERMISSION_GRANTED
+                ) {
+                    // Ask for the permission first; enableAlertNotifications runs on grant.
+                    notifPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                } else {
+                    enableAlertNotifications()
+                }
+            }
+            .setNegativeButton("Not now", null)
+            .show()
+    }
+
+    /**
+     * Turn on Alert notifications and bring the listener service up. Alerts default on
+     * and Detections stay off (the user opts into the noisier stream in Settings).
+     * Enabling straight from here deliberately skips the DND / battery-optimization
+     * prompts that Settings shows, keeping this a single, quiet action.
+     */
+    private fun enableAlertNotifications() {
+        if (!isAdded) return
+        val prefs = PreferenceManager.getDefaultSharedPreferences(requireContext())
+        prefs.edit()
+            .putBoolean("notifications_enabled", true)
+            .putBoolean("notify_alerts", true)
+            .apply()
+        com.asksakis.freegate.notifications.FrigateAlertService.markListeningSince(requireContext())
+        com.asksakis.freegate.notifications.FrigateAlertService
+            .updateForContext(requireContext(), forceRestart = true)
+        Toast.makeText(context, "Alert notifications enabled", Toast.LENGTH_SHORT).show()
+        promptBatteryOptimizationForNotifications(prefs)
+    }
+
+    /**
+     * Notification-reliability boundary: Android can silently kill the background WS
+     * listener under battery optimization, so right after enabling alerts we offer the
+     * exemption. Reuses [BatteryOptHelper] and the same `battery_opt_prompted` flag as
+     * the Settings screen, so the user is never asked twice. DND access is intentionally
+     * left to Settings to keep this a single, light prompt.
+     */
+    private fun promptBatteryOptimizationForNotifications(
+        prefs: android.content.SharedPreferences,
+    ) {
+        val ctx = context ?: return
+        if (com.asksakis.freegate.notifications.BatteryOptHelper.isIgnoringOptimizations(ctx)) {
+            prefs.edit().putBoolean("battery_opt_prompted", true).apply()
+            return
+        }
+        com.asksakis.freegate.ui.FreegateDialogs.builder(ctx)
+            .setTitle("Keep notifications reliable")
+            .setMessage(
+                "Android may silently kill the background listener after a while. Allow " +
+                    "Phylax to bypass battery optimization so alerts arrive reliably?"
+            )
+            .setPositiveButton("Allow") { _, _ ->
+                com.asksakis.freegate.notifications.BatteryOptHelper.requestIgnore(ctx)
+                prefs.edit().putBoolean("battery_opt_prompted", true).apply()
+            }
+            .setNegativeButton("Not now") { _, _ ->
+                prefs.edit().putBoolean("battery_opt_prompted", true).apply()
+            }
+            .show()
     }
 
     /**
@@ -484,13 +619,22 @@ class HomeFragment : Fragment() {
         // Also observe the URL validation status
         networkUtils.urlValidationStatus.observe(viewLifecycleOwner) { result ->
             when (result.status) {
+                NetworkUtils.ValidationStatus.UNCONFIGURED -> {
+                    // No server configured (fresh install or last server deleted).
+                    // This is not a failure: show the setup empty state and stop.
+                    Log.d(TAG, "URL validation reports unconfigured - showing setup empty state")
+                    networkValidationInProgress = false
+                    showSetupEmptyState()
+                }
                 NetworkUtils.ValidationStatus.IN_PROGRESS -> {
                     Log.d(TAG, "URL validation in progress: ${result.url}")
                     networkValidationInProgress = true
+                    hideSetupEmptyState()
                 }
                 NetworkUtils.ValidationStatus.SUCCESS -> {
                     Log.d(TAG, "URL validation succeeded: ${result.url} - ${result.message}")
                     networkValidationInProgress = false
+                    hideSetupEmptyState()
 
                     // If an endpoint-mode switch queued a reload, the server is now
                     // provably reachable via the new path — trigger the WebView reload
@@ -501,6 +645,8 @@ class HomeFragment : Fragment() {
                         Log.d(TAG, "Validation SUCCESS — triggering queued reload: $target")
                         loadUrlWithConnectivityCheck(target)
                     }
+                    // First successful connect right after adding a server: offer alerts.
+                    maybeOfferNotifications()
                 }
                 NetworkUtils.ValidationStatus.FAILED, NetworkUtils.ValidationStatus.TIMEOUT -> {
                     Log.d(TAG, "URL validation failed: ${result.url} - ${result.message}")
@@ -669,6 +815,50 @@ class HomeFragment : Fragment() {
             
             fileUploadCallback?.onReceiveValue(results)
             fileUploadCallback = null
+        }
+
+        // Registered here (before the fragment is STARTED) so it's ready by the time
+        // the user taps two-way talk. The WebView request is deferred until the user
+        // answers the system mic prompt, then granted/denied accordingly.
+        micPermissionLauncher = registerForActivityResult(
+            ActivityResultContracts.RequestPermission()
+        ) { granted ->
+            val request = pendingAudioRequest
+            pendingAudioRequest = null
+            if (request == null) return@registerForActivityResult
+            try {
+                if (granted) {
+                    Log.d(TAG, "Mic granted - granting audio capture to WebView")
+                    request.grant(arrayOf(PermissionRequest.RESOURCE_AUDIO_CAPTURE))
+                } else {
+                    Log.d(TAG, "Mic denied - two-way talk unavailable")
+                    Toast.makeText(
+                        context,
+                        "Microphone denied - two-way talk is unavailable",
+                        Toast.LENGTH_SHORT,
+                    ).show()
+                    request.deny()
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Error resolving deferred audio request: ${e.message}")
+                runCatching { request.deny() }
+            }
+        }
+
+        // Post-setup notification offer: on grant, enable alerts + start the service;
+        // on denial, leave notifications off (nothing to enable if it can't be shown).
+        notifPermissionLauncher = registerForActivityResult(
+            ActivityResultContracts.RequestPermission()
+        ) { granted ->
+            if (granted) {
+                enableAlertNotifications()
+            } else {
+                Toast.makeText(
+                    context,
+                    "You can enable notifications later in Settings",
+                    Toast.LENGTH_SHORT,
+                ).show()
+            }
         }
     }
     
@@ -1095,7 +1285,15 @@ class HomeFragment : Fragment() {
                                 Log.d(TAG, "Granting RESOURCE_AUDIO_CAPTURE permission to WebView")
                                 resourceList.add(PermissionRequest.RESOURCE_AUDIO_CAPTURE)
                             } else {
-                                Log.d(TAG, "Cannot grant RESOURCE_AUDIO_CAPTURE - Android permission not granted")
+                                // Feature boundary: the user just invoked two-way talk and
+                                // we don't hold the mic yet. Ask for it now and defer this
+                                // WebView request until they answer - the launcher callback
+                                // grants or denies it. Bail out of the rest of the handler
+                                // so we don't deny the request prematurely.
+                                Log.d(TAG, "Two-way talk needs mic - requesting RECORD_AUDIO now")
+                                pendingAudioRequest = request
+                                micPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
+                                return@let
                             }
                         }
 
@@ -1246,7 +1444,13 @@ class HomeFragment : Fragment() {
         // Handle file upload callback first
         fileUploadCallback?.onReceiveValue(null)
         fileUploadCallback = null
-        
+
+        // Deny and drop any two-way-talk mic request still waiting on the system
+        // prompt, so the launcher callback can't act on a request tied to this
+        // (now torn-down) WebView after the view is destroyed.
+        pendingAudioRequest?.let { runCatching { it.deny() } }
+        pendingAudioRequest = null
+
         try {
             // Use safe binding access to prevent crashes during cleanup
             _binding?.let { safeBinding ->
@@ -1474,24 +1678,14 @@ class HomeFragment : Fragment() {
      */
     private fun setupMediaPermissions() {
         try {
-            val perms = arrayOf(
-                Manifest.permission.RECORD_AUDIO,
-                Manifest.permission.MODIFY_AUDIO_SETTINGS,
-            )
-            val missing = perms.filter {
-                ContextCompat.checkSelfPermission(requireContext(), it) !=
-                    PackageManager.PERMISSION_GRANTED
-            }
-
-            if (missing.isEmpty()) {
-                Log.d(TAG, "WebRTC audio/video permissions granted")
-                binding.webView.settings.mediaPlaybackRequiresUserGesture = false
-                applyAudioMode()
-                // WebChromeClient.onPermissionRequest will deliver the permissions to the WebView.
-            } else {
-                Log.d(TAG, "Requesting WebRTC permissions: ${missing.joinToString()}")
-                ActivityCompat.requestPermissions(requireActivity(), missing.toTypedArray(), 102)
-            }
+            // Do NOT request RECORD_AUDIO up front - that was one of the launch-time
+            // prompts new users saw before they knew why. The mic is a two-way-talk
+            // feature, so we ask for it lazily in onPermissionRequest the first time
+            // the Frigate page actually requests audio capture (user taps talk).
+            // MODIFY_AUDIO_SETTINGS is a normal install-time permission, so no runtime
+            // request is needed here. Configure media playback either way.
+            binding.webView.settings.mediaPlaybackRequiresUserGesture = false
+            applyAudioMode()
         } catch (e: Exception) {
             Log.e(TAG, "Error setting up WebRTC media permissions: ${e.message}")
         }

--- a/app/src/main/java/com/asksakis/freegate/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/asksakis/freegate/ui/home/HomeFragment.kt
@@ -17,6 +17,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.WindowInsets
 import android.view.WindowInsetsController
+import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
@@ -103,6 +104,14 @@ class HomeFragment : Fragment() {
     private var customView: View? = null
     private var customViewCallback: WebChromeClient.CustomViewCallback? = null
     private var wasSystemBarsVisible: Boolean = true
+
+    /**
+     * Window display-cutout mode saved when entering fullscreen, restored on exit.
+     * During fullscreen we use SHORT_EDGES and pad the fullscreen view by the live
+     * displayCutout insets, so the video and Frigate's own controls stay clear of the
+     * punch-hole/notch. Outside fullscreen we keep the window's original mode.
+     */
+    private var savedCutoutMode: Int? = null
 
     private lateinit var clientCertManager: ClientCertManager
     private lateinit var downloadHandler: DownloadHandler
@@ -1330,44 +1339,71 @@ class HomeFragment : Fragment() {
                 
                 override fun onShowCustomView(view: View?, callback: WebChromeClient.CustomViewCallback?) {
                     Log.d(TAG, "Entering fullscreen mode")
-                    
+
                     if (customView != null) {
                         onHideCustomView()
                         return
                     }
-                    
-                    customView = view
+                    if (view == null) return
+
                     customViewCallback = callback
-                    
-                    // Hide system UI for immersive fullscreen using modern API
+
+                    // Attach the player's fullscreen view to the window's top-level decor,
+                    // NOT to a container nested inside the fragment. That nested container
+                    // sits below our toolbar (CoordinatorLayout content area), so the video
+                    // would open "fullscreen" with our app bar still on top. Overlaying the
+                    // decor covers the toolbar and everything else for a true fullscreen.
+                    val decor = activity?.window?.decorView as? android.widget.FrameLayout
+                    if (decor == null) {
+                        customViewCallback = null
+                        callback?.onCustomViewHidden()
+                        return
+                    }
+                    // Wrap the player in a black container we pad by the display-cutout
+                    // insets, so the player is laid out inside the wrapper's content box
+                    // (the safe area). Padding the player view directly is unreliable - a
+                    // Chromium video surface renders to its full bounds ignoring padding -
+                    // whereas a child at MATCH_PARENT honours the parent's padding. This
+                    // keeps the video and Frigate's own controls clear of the punch-hole,
+                    // which the window's NEVER cutout mode failed to do at runtime on Samsung.
+                    val wrapper = android.widget.FrameLayout(requireContext()).apply {
+                        setBackgroundColor(android.graphics.Color.BLACK)
+                        addView(
+                            view,
+                            android.widget.FrameLayout.LayoutParams(
+                                ViewGroup.LayoutParams.MATCH_PARENT,
+                                ViewGroup.LayoutParams.MATCH_PARENT,
+                            ),
+                        )
+                    }
+                    customView = wrapper
+                    decor.addView(
+                        wrapper,
+                        android.widget.FrameLayout.LayoutParams(
+                            ViewGroup.LayoutParams.MATCH_PARENT,
+                            ViewGroup.LayoutParams.MATCH_PARENT,
+                        ),
+                    )
                     hideSystemBars()
-                    
-                    // Hide normal content and show fullscreen container
-                    binding.swipeRefresh.visibility = View.GONE
-                    binding.swipeRefresh.isRefreshing = false
-                    binding.fullscreenContainer.visibility = View.VISIBLE
-                    
-                    // Add custom view to fullscreen container
-                    binding.fullscreenContainer.addView(view)
+                    applyFullscreenCutoutMode()
+                    ViewCompat.setOnApplyWindowInsetsListener(wrapper) { v, insets ->
+                        val cut = insets.getInsets(WindowInsetsCompat.Type.displayCutout())
+                        v.setPadding(cut.left, cut.top, cut.right, cut.bottom)
+                        insets
+                    }
+                    ViewCompat.requestApplyInsets(wrapper)
                 }
-                
+
                 override fun onHideCustomView() {
                     Log.d(TAG, "Exiting fullscreen mode")
-                    
-                    if (customView == null) return
-                    
-                    // Remove custom view from container
-                    binding.fullscreenContainer.removeView(customView)
+
+                    val view = customView ?: return
+                    (activity?.window?.decorView as? android.widget.FrameLayout)?.removeView(view)
                     customView = null
-                    
-                    // Hide fullscreen container and show normal content
-                    binding.fullscreenContainer.visibility = View.GONE
-                    binding.swipeRefresh.visibility = View.VISIBLE
-                    
-                    // Restore system UI visibility using modern API
+
                     showSystemBars()
-                    
-                    // Notify callback that we're done
+                    restoreCutoutMode()
+
                     customViewCallback?.onCustomViewHidden()
                     customViewCallback = null
                 }
@@ -1430,15 +1466,17 @@ class HomeFragment : Fragment() {
     }
     
     override fun onDestroyView() {
-        // Clean up fullscreen mode if active
+        // Clean up fullscreen mode if active (the player view is attached to the
+        // window decor, so remove it from there).
         if (customView != null) {
             Log.d(TAG, "Cleaning up fullscreen mode during destroy")
-            binding.fullscreenContainer.removeView(customView)
+            (activity?.window?.decorView as? android.widget.FrameLayout)?.removeView(customView)
             customView = null
             customViewCallback?.onCustomViewHidden()
             customViewCallback = null
             // Restore system UI visibility using modern API
             showSystemBars()
+            restoreCutoutMode()
         }
         
         // Handle file upload callback first
@@ -1950,6 +1988,34 @@ class HomeFragment : Fragment() {
                 window.decorView.systemUiVisibility = View.SYSTEM_UI_FLAG_VISIBLE
             }
         }
+    }
+
+    /**
+     * While fullscreen, keep the window clear of the display cutout (punch-hole/notch)
+     * so the page's video and Frigate's own player controls are never obscured by it.
+     * The system letterboxes the cutout edge. No-op below API 28; safe on devices
+     * without a cutout.
+     */
+    private fun applyFullscreenCutoutMode() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) return
+        val window = activity?.window ?: return
+        if (savedCutoutMode == null) savedCutoutMode = window.attributes.layoutInDisplayCutoutMode
+        // SHORT_EDGES so the window extends into the cutout and the displayCutout inset
+        // is reported to our fullscreen view; the inset listener there pads the content
+        // back into the safe area (reliable across OEMs, unlike relying on NEVER).
+        window.attributes = window.attributes.apply {
+            layoutInDisplayCutoutMode =
+                android.view.WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
+        }
+    }
+
+    /** Restore the window's original display-cutout mode after leaving fullscreen. */
+    private fun restoreCutoutMode() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) return
+        val window = activity?.window ?: return
+        val prev = savedCutoutMode ?: return
+        window.attributes = window.attributes.apply { layoutInDisplayCutoutMode = prev }
+        savedCutoutMode = null
     }
 
     /**

--- a/app/src/main/java/com/asksakis/freegate/ui/settings/AdvancedSettingsFragment.kt
+++ b/app/src/main/java/com/asksakis/freegate/ui/settings/AdvancedSettingsFragment.kt
@@ -1,43 +1,17 @@
 package com.asksakis.freegate.ui.settings
 
 import android.os.Bundle
-import android.widget.Toast
-import androidx.preference.EditTextPreference
 import androidx.preference.PreferenceFragmentCompat
-import androidx.preference.SwitchPreferenceCompat
 import com.asksakis.freegate.R
 
 /**
- * Power-user knobs only: voice-call audio routing and custom WebView User Agent.
- * Anything release/identity-related (version, "what's new", check for updates)
- * lives under Settings → About so the per-screen mental model stays clean.
+ * Power-user knobs only: voice-call audio routing. Anything release/identity-related
+ * (version, "what's new", check for updates) lives under Settings -> About so the
+ * per-screen mental model stays clean.
  */
 class AdvancedSettingsFragment : PreferenceFragmentCompat() {
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         setPreferencesFromResource(R.xml.prefs_advanced, rootKey)
-
-        val customUa = findPreference<EditTextPreference>("custom_user_agent")
-        customUa?.summaryProvider = EditTextPreference.SimpleSummaryProvider.getInstance()
-
-        findPreference<SwitchPreferenceCompat>("use_custom_user_agent")
-            ?.setOnPreferenceChangeListener { _, newValue ->
-                val msg = if (newValue as Boolean) {
-                    "Custom User Agent enabled. The page will reload with new settings."
-                } else {
-                    "Using default User Agent"
-                }
-                Toast.makeText(requireContext(), msg, Toast.LENGTH_SHORT).show()
-                true
-            }
-
-        customUa?.setOnPreferenceChangeListener { _, _ ->
-            Toast.makeText(
-                requireContext(),
-                "User Agent updated. The page will reload with new settings.",
-                Toast.LENGTH_SHORT,
-            ).show()
-            true
-        }
     }
 }

--- a/app/src/main/java/com/asksakis/freegate/ui/settings/ConnectionSettingsFragment.kt
+++ b/app/src/main/java/com/asksakis/freegate/ui/settings/ConnectionSettingsFragment.kt
@@ -1,7 +1,9 @@
 package com.asksakis.freegate.ui.settings
 
+import android.Manifest
 import android.app.AlertDialog
 import android.content.Context
+import android.content.pm.PackageManager
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.net.wifi.WifiManager
@@ -18,6 +20,7 @@ import android.view.inputmethod.EditorInfo
 import android.widget.EditText
 import android.widget.LinearLayout
 import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
 import androidx.navigation.fragment.findNavController
 import androidx.preference.EditTextPreference
@@ -46,6 +49,48 @@ class ConnectionSettingsFragment : PreferenceFragmentCompat() {
                 com.asksakis.freegate.utils.OkHttpClientFactory.invalidate()
             }
         }
+
+    /**
+     * Feature-boundary location request. Reading the current Wi-Fi SSID (for auto
+     * URL switching and the home-network picker) requires ACCESS_FINE_LOCATION on
+     * every supported Android version, so we ask for it here - when the user opts
+     * into an SSID-based feature - instead of up front at app launch.
+     */
+    private val locationPermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        if (granted) {
+            networkUtils.forceRefresh()
+            updateWifiStatus()
+            populateHomeWifiEntries()
+        } else {
+            Toast.makeText(
+                requireContext(),
+                "Location denied - automatic Wi-Fi URL switching won't work",
+                Toast.LENGTH_LONG,
+            ).show()
+        }
+    }
+
+    /** Prompt for location the first time an SSID-based feature is used. No-op if granted. */
+    private fun ensureLocationForSsid() {
+        val granted = ContextCompat.checkSelfPermission(
+            requireContext(), Manifest.permission.ACCESS_FINE_LOCATION,
+        ) == PackageManager.PERMISSION_GRANTED
+        if (granted) return
+        com.asksakis.freegate.ui.FreegateDialogs.builder(requireContext())
+            .setTitle("Location needed for Wi-Fi switching")
+            .setMessage(
+                "Phylax reads your current Wi-Fi network name to switch between the local " +
+                    "and remote Frigate URLs automatically. It is used only for that - no GPS, " +
+                    "no tracking. Grant location access?"
+            )
+            .setPositiveButton("Continue") { _, _ ->
+                locationPermissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION)
+            }
+            .setNegativeButton("Not now", null)
+            .show()
+    }
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         setPreferencesFromResource(R.xml.prefs_connection, rootKey)
@@ -289,6 +334,9 @@ class ConnectionSettingsFragment : PreferenceFragmentCompat() {
                     NetworkUtils.ValidationStatus.SUCCESS -> "✓ ${r.message}"
                     NetworkUtils.ValidationStatus.FAILED,
                     NetworkUtils.ValidationStatus.TIMEOUT -> "✗ ${r.message}"
+                    // Unconfigured carries a null url, so the probingUrl filter above
+                    // already dropped it; this branch just satisfies exhaustiveness.
+                    NetworkUtils.ValidationStatus.UNCONFIGURED -> return@Observer
                 },
             )
         }
@@ -386,6 +434,9 @@ class ConnectionSettingsFragment : PreferenceFragmentCompat() {
             }
             toast?.let { Toast.makeText(requireContext(), it, Toast.LENGTH_SHORT).show() }
 
+            // Auto mode is the only mode that reads the SSID - ask for location here.
+            if (newValue.toString() == "auto") ensureLocationForSsid()
+
             view?.post {
                 applyConnectionModeVisibility()
                 updateWifiStatus()
@@ -405,6 +456,8 @@ class ConnectionSettingsFragment : PreferenceFragmentCompat() {
         triggerWifiScan()
 
         networksPref?.setOnPreferenceClickListener {
+            // Opening the picker reads nearby/active SSIDs, which needs location.
+            ensureLocationForSsid()
             // Picker about to open — re-scan and re-populate so freshly-visible
             // networks appear without forcing the user to back out and re-enter.
             triggerWifiScan()
@@ -418,6 +471,8 @@ class ConnectionSettingsFragment : PreferenceFragmentCompat() {
         }
 
         addPref?.setOnPreferenceClickListener {
+            // Pre-filling the dialog with the current SSID needs location too.
+            ensureLocationForSsid()
             val input = EditText(requireContext()).apply {
                 inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS
                 imeOptions = EditorInfo.IME_FLAG_NO_FULLSCREEN or EditorInfo.IME_FLAG_NO_EXTRACT_UI

--- a/app/src/main/java/com/asksakis/freegate/ui/settings/NotificationsSettingsFragment.kt
+++ b/app/src/main/java/com/asksakis/freegate/ui/settings/NotificationsSettingsFragment.kt
@@ -1,13 +1,17 @@
 package com.asksakis.freegate.ui.settings
 
+import android.Manifest
 import android.app.AlertDialog
 import android.app.NotificationManager
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
 import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.preference.Preference
@@ -53,6 +57,10 @@ class NotificationsSettingsFragment : PreferenceFragmentCompat() {
             if (key == "notifications_enabled" &&
                 prefs.getBoolean("notifications_enabled", false)
             ) {
+                // Feature boundary: enabling alerts is when we ask for the notification
+                // permission (Android 13+). Without it, FrigateNotifier silently drops
+                // every alert - so request it here rather than at app launch.
+                maybeRequestNotificationPermission()
                 if (!prefs.getBoolean("battery_opt_prompted", false)) {
                     maybePromptBatteryOptimization(autoPrompt = true)
                 }
@@ -143,6 +151,30 @@ class NotificationsSettingsFragment : PreferenceFragmentCompat() {
         }
         if (pickerOpened && selected.size >= total) return "All ${kind}s"
         return selected.sorted().joinToString(", ")
+    }
+
+    /** POST_NOTIFICATIONS request, fired when the user first enables alerts (API 33+). */
+    private val notificationPermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        if (!granted) {
+            Toast.makeText(
+                requireContext(),
+                "Notifications permission denied - alerts won't appear",
+                Toast.LENGTH_LONG,
+            ).show()
+        }
+    }
+
+    /** Ask for POST_NOTIFICATIONS on Android 13+ if it isn't already granted. */
+    private fun maybeRequestNotificationPermission() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return
+        val granted = ContextCompat.checkSelfPermission(
+            requireContext(), Manifest.permission.POST_NOTIFICATIONS,
+        ) == PackageManager.PERMISSION_GRANTED
+        if (!granted) {
+            notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+        }
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/com/asksakis/freegate/ui/settings/ServersFragment.kt
+++ b/app/src/main/java/com/asksakis/freegate/ui/settings/ServersFragment.kt
@@ -11,6 +11,7 @@ import android.widget.PopupMenu
 import android.widget.TextView
 import android.widget.Toast
 import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.asksakis.freegate.R
@@ -135,21 +136,31 @@ class ServersFragment : Fragment(R.layout.fragment_servers) {
     }
 
     private fun confirmDelete(profile: ServerProfile) {
-        if (store.getAll().size <= 1) {
-            Toast.makeText(requireContext(), "Can't delete the only server", Toast.LENGTH_SHORT).show()
-            return
+        val isLast = store.getAll().size <= 1
+        val message = if (isLast) {
+            "This removes your only server and its stored credentials, URLs, and notification filters. " +
+                "The app returns to the setup screen. Cannot be undone."
+        } else {
+            "This removes the server and its stored credentials, URLs, and notification filters. Cannot be undone."
         }
         com.asksakis.freegate.ui.FreegateDialogs.builder(requireContext())
             .setTitle("Delete ${profile.name}?")
-            .setMessage("This removes the server and its stored credentials, URLs, and notification filters. Cannot be undone.")
+            .setMessage(message)
             .setPositiveButton("Delete") { _, _ ->
                 val wasActive = profile.id == store.getActiveId()
                 store.delete(profile.id)
-                // Only restart the listener when we deleted the active profile —
-                // `store.delete` auto-promotes the next profile, so the flat keys
+                // Only restart the listener when we deleted the active profile.
+                // `store.delete` auto-promotes the next profile (or drops to the
+                // unconfigured state when it was the last one), so the flat keys
                 // have moved.
                 FrigateAlertService.updateForContext(requireContext(), forceRestart = wasActive)
-                adapter.submit(store.getAll(), store.getActiveId())
+                if (isLast) {
+                    // No servers left: pop straight back to Home, which now shows the
+                    // setup empty state (matches the dialog's "returns to setup" promise).
+                    findNavController().popBackStack(R.id.nav_home, false)
+                } else {
+                    adapter.submit(store.getAll(), store.getActiveId())
+                }
             }
             .setNegativeButton("Cancel", null)
             .show()

--- a/app/src/main/java/com/asksakis/freegate/ui/setup/SetupFragment.kt
+++ b/app/src/main/java/com/asksakis/freegate/ui/setup/SetupFragment.kt
@@ -1,0 +1,251 @@
+package com.asksakis.freegate.ui.setup
+
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.view.View
+import android.widget.TextView
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
+import androidx.preference.PreferenceManager
+import com.asksakis.freegate.R
+import com.asksakis.freegate.auth.ServerProfileStore
+import com.asksakis.freegate.notifications.FrigateAlertService
+import com.asksakis.freegate.utils.ClientCertManager
+import com.asksakis.freegate.utils.NetworkUtils
+import com.asksakis.freegate.utils.OkHttpClientFactory
+import com.asksakis.freegate.utils.UrlNormalizer
+import com.google.android.material.button.MaterialButton
+import com.google.android.material.textfield.TextInputEditText
+import com.google.android.material.textfield.TextInputLayout
+import okhttp3.Request
+
+/**
+ * First-run / add-server screen. A focused form: the Frigate URL is the one required
+ * field; name and credentials are optional; a separate LAN URL hides under Advanced.
+ *
+ * On save it creates and activates a real profile via [ServerProfileStore] and calls
+ * [NetworkUtils.start] so networking comes online only now - never on a blank config.
+ * That, together with the Home empty state, is what replaces the old "connect on
+ * launch and spam failure toasts" first-run behaviour.
+ */
+class SetupFragment : Fragment(R.layout.fragment_setup) {
+
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    /**
+     * Location request fired at save time only when a separate LAN URL is configured
+     * (auto LAN/remote switching needs the SSID). Whatever the user answers, we then
+     * refresh networking and return to Home.
+     */
+    private val locationPermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { _ ->
+        if (isAdded) NetworkUtils.getInstance(requireContext()).forceRefresh()
+        goHome()
+    }
+
+    private lateinit var urlLayout: TextInputLayout
+    private lateinit var urlInput: TextInputEditText
+    private lateinit var nameInput: TextInputEditText
+    private lateinit var usernameInput: TextInputEditText
+    private lateinit var passwordInput: TextInputEditText
+    private lateinit var internalUrlLayout: TextInputLayout
+    private lateinit var internalUrlInput: TextInputEditText
+    private lateinit var advancedSection: View
+    private lateinit var statusView: TextView
+    private lateinit var testButton: MaterialButton
+    private lateinit var saveButton: MaterialButton
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        urlLayout = view.findViewById(R.id.setup_url_layout)
+        urlInput = view.findViewById(R.id.setup_url)
+        nameInput = view.findViewById(R.id.setup_name)
+        usernameInput = view.findViewById(R.id.setup_username)
+        passwordInput = view.findViewById(R.id.setup_password)
+        internalUrlLayout = view.findViewById(R.id.setup_internal_url_layout)
+        internalUrlInput = view.findViewById(R.id.setup_internal_url)
+        advancedSection = view.findViewById(R.id.setup_advanced_section)
+        statusView = view.findViewById(R.id.setup_status)
+        testButton = view.findViewById(R.id.setup_test_button)
+        saveButton = view.findViewById(R.id.setup_save_button)
+
+        view.findViewById<MaterialButton>(R.id.setup_advanced_toggle).setOnClickListener {
+            advancedSection.visibility =
+                if (advancedSection.visibility == View.VISIBLE) View.GONE else View.VISIBLE
+        }
+
+        // Clear the inline URL error as the user edits - next Test/Save recomputes it.
+        urlInput.setOnFocusChangeListener { _, hasFocus -> if (hasFocus) urlLayout.error = null }
+
+        testButton.setOnClickListener { onTest() }
+        saveButton.setOnClickListener { onSave() }
+    }
+
+    /** Normalise the primary URL. Local Frigate installs are http by default. */
+    private fun normalizePrimary(): UrlNormalizer.Result =
+        UrlNormalizer.normalize(urlInput.text?.toString().orEmpty(), external = false)
+
+    private fun onTest() {
+        val result = normalizePrimary()
+        val url = result.normalized
+        if (url == null) {
+            urlLayout.error = result.error ?: getString(R.string.setup_url_hint)
+            return
+        }
+        urlLayout.error = null
+        setBusy(true)
+        showStatus(getString(R.string.setup_testing), R.color.text_secondary)
+        Thread {
+            val probe = probe(url)
+            mainHandler.post {
+                if (!isAdded) return@post
+                setBusy(false)
+                if (probe.reachable) {
+                    showStatus("✓ ${getString(R.string.setup_test_ok)} (${probe.detail})", R.color.status_ok)
+                } else {
+                    showStatus("✗ ${probe.detail}", R.color.status_failed)
+                }
+            }
+        }.start()
+    }
+
+    private data class ProbeResult(val reachable: Boolean, val detail: String)
+
+    /**
+     * One-shot HEAD probe using the shared client factory (same TLS/mTLS policy as
+     * the rest of the app). Any HTTP response - including 401/403 - means the server
+     * is reachable; only transport errors count as unreachable.
+     */
+    private fun probe(url: String): ProbeResult {
+        return try {
+            val client = OkHttpClientFactory.build(
+                url,
+                ClientCertManager.getInstance(requireContext()),
+                OkHttpClientFactory.Timeouts(connectSeconds = 8, readSeconds = 8),
+            )
+            val request = Request.Builder()
+                .url(url)
+                .head()
+                .header("User-Agent", "Mozilla/5.0 Phylax/1.0 Setup")
+                .build()
+            client.newCall(request).execute().use { resp ->
+                ProbeResult(reachable = true, detail = "HTTP ${resp.code}")
+            }
+        } catch (e: Exception) {
+            ProbeResult(reachable = false, detail = e.message ?: "Connection failed")
+        }
+    }
+
+    private fun onSave() {
+        val result = normalizePrimary()
+        val primary = result.normalized
+        if (primary == null) {
+            urlLayout.error = result.error ?: "Enter a valid URL"
+            return
+        }
+        urlLayout.error = null
+
+        // Optional separate LAN URL. When present it becomes the internal URL and the
+        // primary is used as the external one; otherwise the single URL serves both so
+        // auto mode resolves regardless of which network the user is on.
+        val rawInternal = internalUrlInput.text?.toString().orEmpty().trim()
+        val internalUrl: String?
+        val externalUrl: String?
+        if (rawInternal.isNotEmpty()) {
+            val internalResult = UrlNormalizer.normalize(rawInternal, external = false)
+            if (internalResult.normalized == null) {
+                internalUrlLayout.error = internalResult.error ?: "Enter a valid URL"
+                advancedSection.visibility = View.VISIBLE
+                return
+            }
+            internalUrlLayout.error = null
+            internalUrl = internalResult.normalized
+            externalUrl = primary
+        } else {
+            internalUrl = primary
+            externalUrl = primary
+        }
+
+        val store = ServerProfileStore.getInstance(requireContext())
+        store.createAndActivate(
+            name = nameInput.text?.toString().orEmpty().ifBlank { "Frigate" },
+            internalUrl = internalUrl,
+            externalUrl = externalUrl,
+            username = usernameInput.text?.toString(),
+            password = passwordInput.text?.toString(),
+        )
+
+        // Arm the one-time "Enable notifications?" offer. HomeFragment shows it after
+        // the first successful connection, so the prompt is tied to adding a server
+        // (never shown to existing users on upgrade) and never fires on a dead URL.
+        PreferenceManager.getDefaultSharedPreferences(requireContext())
+            .edit().putBoolean(PREF_PENDING_NOTIF_OFFER, true).apply()
+
+        // Networking was idle until now; bring it online for the freshly saved server.
+        NetworkUtils.getInstance(requireContext()).start()
+        // Respect an already-enabled notification preference (unlikely on first run,
+        // but harmless): re-evaluate the alert service against the new server.
+        FrigateAlertService.updateForContext(requireContext(), forceRestart = true)
+
+        // Reliability boundary: a separate LAN URL means auto LAN/remote switching is in
+        // play, which needs the current Wi-Fi SSID (ACCESS_FINE_LOCATION). Ask for it now,
+        // only in that case - a single-URL setup never needs it. Navigate to Home after
+        // the user answers so the system prompt isn't left dangling over Home.
+        if (rawInternal.isNotEmpty() && !hasLocationPermission()) {
+            com.asksakis.freegate.ui.FreegateDialogs.builder(requireContext())
+                .setTitle("Location for automatic switching")
+                .setMessage(
+                    "You added a separate local URL. Phylax reads your current Wi-Fi network " +
+                        "name to switch between the local and remote URL automatically. It is " +
+                        "used only for that - no GPS, no tracking. Grant location access?"
+                )
+                .setPositiveButton("Continue") { _, _ ->
+                    locationPermissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION)
+                }
+                .setNegativeButton("Skip") { _, _ -> goHome() }
+                .setOnCancelListener { goHome() }
+                .show()
+        } else {
+            goHome()
+        }
+    }
+
+    private fun hasLocationPermission(): Boolean =
+        ContextCompat.checkSelfPermission(
+            requireContext(), Manifest.permission.ACCESS_FINE_LOCATION,
+        ) == PackageManager.PERMISSION_GRANTED
+
+    /** Return to Home, which leaves the setup empty state and loads the WebView. */
+    private fun goHome() {
+        if (!isAdded) return
+        if (!findNavController().popBackStack(R.id.nav_home, false)) {
+            findNavController().navigate(R.id.nav_home)
+        }
+    }
+
+    private fun setBusy(busy: Boolean) {
+        testButton.isEnabled = !busy
+        saveButton.isEnabled = !busy
+    }
+
+    private fun showStatus(text: String, colorRes: Int) {
+        statusView.text = text
+        statusView.setTextColor(ContextCompat.getColor(requireContext(), colorRes))
+        statusView.visibility = View.VISIBLE
+    }
+
+    companion object {
+        /**
+         * Set true when a server is added here; consumed once by HomeFragment to show
+         * the one-time "Enable notifications?" offer after the first successful connect.
+         */
+        const val PREF_PENDING_NOTIF_OFFER = "pending_notif_offer"
+    }
+}

--- a/app/src/main/java/com/asksakis/freegate/utils/NetworkUtils.kt
+++ b/app/src/main/java/com/asksakis/freegate/utils/NetworkUtils.kt
@@ -139,7 +139,13 @@ class NetworkUtils private constructor(private val context: Context) {
     
     // Enum to represent validation results
     enum class ValidationStatus {
-        IN_PROGRESS, SUCCESS, FAILED, TIMEOUT
+        IN_PROGRESS, SUCCESS, FAILED, TIMEOUT,
+        /**
+         * No usable server is configured yet (fresh install or the last server was
+         * deleted). This is application state, NOT a connection failure: the Home
+         * screen shows the setup empty state and no toast/error is raised.
+         */
+        UNCONFIGURED
     }
     
     // Data class for validation result
@@ -166,8 +172,18 @@ class NetworkUtils private constructor(private val context: Context) {
     )
     
     init {
-        checkAndUpdateUrl()
-        registerCallback()
+        // Fresh installs (and users who deleted their last server) have no usable
+        // endpoint. Stay completely idle: don't register the connectivity callback,
+        // don't validate, don't emit failures. Registering only once a server exists
+        // is what stops the repeating "connection failed" toast on first run. The
+        // setup screen calls start() after saving the first server.
+        if (hasUsableServer()) {
+            checkAndUpdateUrl()
+            registerCallback()
+        } else {
+            Log.d(TAG, "No usable server configured - NetworkUtils staying idle")
+            postUnconfigured()
+        }
     }
     
     /**
@@ -392,6 +408,37 @@ class NetworkUtils private constructor(private val context: Context) {
      * HTTP validation and LiveData emit. With a short debounce we keep the
      * semantics (last writer wins) and fire exactly once.
      */
+    /**
+     * True when the flat endpoint keys hold a real http/https URL. Read directly
+     * from prefs (not via ServerProfileStore) to avoid a circular init dependency:
+     * ServerProfileStore.setActive() constructs NetworkUtils.
+     */
+    private fun hasUsableServer(): Boolean =
+        com.asksakis.freegate.auth.ServerProfile.looksLikeEndpoint(prefs.getString("internal_url", null)) ||
+            com.asksakis.freegate.auth.ServerProfile.looksLikeEndpoint(prefs.getString("external_url", null))
+
+    /** Publish the unconfigured state so Home renders the setup empty screen. */
+    private fun postUnconfigured() {
+        _urlValidationStatus.postValue(
+            ValidationResult(ValidationStatus.UNCONFIGURED, null, false, "No server configured")
+        )
+    }
+
+    /**
+     * Bring networking online after a server is first configured (setup screen) or
+     * re-added. Registers the connectivity callback (idempotent) and kicks a refresh.
+     * No-op while still unconfigured.
+     */
+    fun start() {
+        if (!hasUsableServer()) {
+            Log.d(TAG, "start() ignored - still no usable server")
+            postUnconfigured()
+            return
+        }
+        registerCallback()
+        forceRefresh()
+    }
+
     fun forceRefresh() {
         Log.d(TAG, "Force refresh requested (debounced)")
         scheduledTransitionCheck?.let { handler.removeCallbacks(it) }
@@ -427,12 +474,10 @@ class NetworkUtils private constructor(private val context: Context) {
      */
     fun validateUrl(url: String?, isInternal: Boolean = false, fallbackUrl: String? = null) {
         if (url == null || url.isEmpty()) {
-            _urlValidationStatus.postValue(ValidationResult(
-                ValidationStatus.FAILED, 
-                url, 
-                isInternal,
-                "URL is empty or null"
-            ))
+            // An empty URL means "not configured", not "failed to connect". Emitting
+            // FAILED here is what drove the first-run error overlay/toast; surface the
+            // unconfigured state instead so Home shows the setup empty screen.
+            postUnconfigured()
             return
         }
         
@@ -610,7 +655,8 @@ class NetworkUtils private constructor(private val context: Context) {
                     mapOf("url" to url, "response_code" to (outcome.responseCode ?: -1))
                 )
             }
-            ValidationStatus.IN_PROGRESS -> Unit // never published from here
+            ValidationStatus.IN_PROGRESS,
+            ValidationStatus.UNCONFIGURED -> Unit // never published from a validation attempt
         }
     }
 
@@ -674,6 +720,20 @@ class NetworkUtils private constructor(private val context: Context) {
     // and loses the linear mode→wifi→ssid read. Earmarked for the Compose/UrlResolver cut.
     fun checkAndUpdateUrl() {
         try {
+            // Unconfigured: no server yet (or the last was deleted). Blank config is
+            // application state, not a connection failure, so we never validate an
+            // empty URL here - that was the source of the repeating first-run toast.
+            if (!hasUsableServer()) {
+                Log.d(TAG, "checkAndUpdateUrl skipped - no usable server configured")
+                postUnconfigured()
+                return
+            }
+
+            // A server exists now. Ensure the connectivity callback is registered even
+            // if we became configured through a path that didn't call start() (e.g. the
+            // user added a URL from Settings > Connection while unconfigured). Idempotent.
+            registerCallback()
+
             // Generate a network state signature to detect actual changes
             val currentState = buildNetworkStateSignature()
             

--- a/app/src/main/java/com/asksakis/freegate/webview/WebViewConfigurator.kt
+++ b/app/src/main/java/com/asksakis/freegate/webview/WebViewConfigurator.kt
@@ -44,14 +44,14 @@ object WebViewConfigurator {
 
         webView.setLayerType(View.LAYER_TYPE_HARDWARE, null)
 
-        s.userAgentString = resolveUserAgent(prefs)
+        s.userAgentString = resolveUserAgent()
 
         if (BuildConfig.DEBUG) {
             WebView.setWebContentsDebuggingEnabled(true)
         }
     }
 
-    private fun resolveUserAgent(prefs: SharedPreferences): String =
+    private fun resolveUserAgent(): String =
         "Mozilla/5.0 (Linux; Android ${Build.VERSION.RELEASE}; ${Build.MODEL}) " +
             "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Mobile Safari/537.36"
 }

--- a/app/src/main/java/com/asksakis/freegate/webview/WebViewConfigurator.kt
+++ b/app/src/main/java/com/asksakis/freegate/webview/WebViewConfigurator.kt
@@ -51,13 +51,7 @@ object WebViewConfigurator {
         }
     }
 
-    private fun resolveUserAgent(prefs: SharedPreferences): String {
-        val default = "Mozilla/5.0 (Linux; Android ${Build.VERSION.RELEASE}; ${Build.MODEL}) " +
+    private fun resolveUserAgent(prefs: SharedPreferences): String =
+        "Mozilla/5.0 (Linux; Android ${Build.VERSION.RELEASE}; ${Build.MODEL}) " +
             "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Mobile Safari/537.36"
-        return if (prefs.getBoolean("use_custom_user_agent", false)) {
-            prefs.getString("custom_user_agent", default) ?: default
-        } else {
-            default
-        }
-    }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -14,6 +14,7 @@
     tools:context=".MainActivity">
 
     <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/app_bar_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:fitsSystemWindows="true"

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -39,17 +39,6 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 
-    <FrameLayout
-        android:id="@+id/fullscreen_container"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="@android:color/black"
-        android:visibility="gone"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
-
     <!--
         Connecting overlay shown over the WebView during a profile swap, while the
         outgoing page is being torn down and the new profile's session is being

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -141,4 +141,77 @@
         </com.google.android.material.card.MaterialCardView>
     </FrameLayout>
 
+    <!--
+        Setup empty state. Shown when no usable server is configured (fresh install
+        or the last server was deleted). Sits above everything (elevation 16dp) so it
+        fully masks the idle WebView, and it is opaque + clickable so nothing behind
+        it receives touches. This is the app's first-run signpost: it points the user
+        straight at "Add server" instead of leaving them on a blank/erroring viewer.
+    -->
+    <FrameLayout
+        android:id="@+id/setup_empty_state"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="?attr/colorSurface"
+        android:clickable="true"
+        android:focusable="true"
+        android:elevation="16dp"
+        android:visibility="gone"
+        tools:visibility="visible"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:gravity="center"
+            android:orientation="vertical"
+            android:paddingHorizontal="40dp">
+
+            <ImageView
+                android:layout_width="72dp"
+                android:layout_height="72dp"
+                android:src="@drawable/ic_conn_server"
+                android:tint="@color/text_secondary"
+                android:importantForAccessibility="no" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"
+                android:gravity="center"
+                android:text="@string/setup_empty_title"
+                android:textAppearance="?attr/textAppearanceHeadlineSmall"
+                android:textColor="@color/text_primary"
+                android:textStyle="bold" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:gravity="center"
+                android:text="@string/setup_empty_subtitle"
+                android:textAppearance="?attr/textAppearanceBodyMedium"
+                android:textColor="@color/text_secondary" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/setup_add_server"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="32dp"
+                android:text="@string/setup_empty_add_server" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/setup_docs"
+                style="@style/Widget.Material3.Button.TextButton"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:text="@string/setup_empty_docs" />
+        </LinearLayout>
+    </FrameLayout>
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_setup.xml
+++ b/app/src/main/res/layout/fragment_setup.xml
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    First-run setup screen. A plain scrollable form (not a PreferenceScreen) so the
+    URL is the first, most prominent field and everything optional is either clearly
+    marked or tucked under Advanced. Reached from the Home empty state's "Add server".
+-->
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fillViewport="true"
+    android:background="?attr/colorSurface">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingHorizontal="24dp"
+        android:paddingTop="24dp"
+        android:paddingBottom="32dp">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/setup_title"
+            android:textAppearance="?attr/textAppearanceHeadlineSmall"
+            android:textColor="@color/text_primary"
+            android:textStyle="bold" />
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/setup_url_layout"
+            style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:hint="@string/setup_url_hint"
+            app:helperText="@string/setup_url_helper"
+            app:helperTextEnabled="true">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/setup_url"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="textUri"
+                android:maxLines="1"
+                android:imeOptions="actionNext" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/setup_name_layout"
+            style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:hint="@string/setup_name_hint">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/setup_name"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="textCapWords"
+                android:maxLines="1"
+                android:imeOptions="actionNext" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/setup_username_layout"
+            style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:hint="@string/setup_username_hint">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/setup_username"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="textNoSuggestions"
+                android:maxLines="1"
+                android:autofillHints="username"
+                android:imeOptions="actionNext" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/setup_password_layout"
+            style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:hint="@string/setup_password_hint"
+            app:passwordToggleEnabled="true">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/setup_password"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="textPassword"
+                android:maxLines="1"
+                android:autofillHints="password"
+                android:imeOptions="actionDone" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <!-- Advanced toggle: reveals the separate LAN URL field. Collapsed by default. -->
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/setup_advanced_toggle"
+            style="@style/Widget.Material3.Button.TextButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:paddingHorizontal="8dp"
+            android:text="@string/setup_advanced"
+            app:icon="@drawable/ic_add_circle"
+            app:iconGravity="textStart" />
+
+        <LinearLayout
+            android:id="@+id/setup_advanced_section"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:visibility="gone">
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/setup_internal_url_layout"
+                style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:hint="@string/setup_internal_url_hint"
+                app:helperText="@string/setup_internal_url_helper"
+                app:helperTextEnabled="true">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/setup_internal_url"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="textUri"
+                    android:maxLines="1"
+                    android:imeOptions="actionDone" />
+            </com.google.android.material.textfield.TextInputLayout>
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/setup_status"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:gravity="center"
+            android:textAppearance="?attr/textAppearanceBodyMedium"
+            android:visibility="gone"
+            tools:visibility="visible" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/setup_test_button"
+            style="@style/Widget.Material3.Button.TonalButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:text="@string/setup_test" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/setup_save_button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/setup_save" />
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/navigation/mobile_navigation.xml
+++ b/app/src/main/res/navigation/mobile_navigation.xml
@@ -9,7 +9,21 @@
         android:id="@+id/nav_home"
         android:name="com.asksakis.freegate.ui.home.HomeFragment"
         android:label="@string/menu_home"
-        tools:layout="@layout/fragment_home" />
+        tools:layout="@layout/fragment_home">
+        <action
+            android:id="@+id/action_home_to_setup"
+            app:destination="@id/nav_setup"
+            app:enterAnim="@anim/fade_in"
+            app:exitAnim="@anim/fade_out"
+            app:popEnterAnim="@anim/fade_in"
+            app:popExitAnim="@anim/fade_out" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/nav_setup"
+        android:name="com.asksakis.freegate.ui.setup.SetupFragment"
+        android:label="@string/setup_title"
+        tools:layout="@layout/fragment_setup" />
 
     <fragment
         android:id="@+id/nav_settings"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,6 +16,28 @@
     <string name="connecting_error_timeout">Connection timed out.</string>
     <string name="connecting_error_ssl">Secure connection failed.</string>
     <string name="connecting_error_generic">Couldn\'t connect to the server.</string>
+
+    <!-- First-run / unconfigured empty state -->
+    <string name="setup_empty_title">Connect to your Frigate server</string>
+    <string name="setup_empty_subtitle">Phylax needs the address of your Frigate NVR to get started. Add your server and you\'re ready to go.</string>
+    <string name="setup_empty_add_server">Add server</string>
+    <string name="setup_empty_docs">Setup help</string>
+
+    <!-- Setup screen -->
+    <string name="setup_title">Add your Frigate server</string>
+    <string name="setup_url_hint">Frigate URL</string>
+    <string name="setup_url_helper">e.g. http://frigate.local:5000 or https://frigate.example.com</string>
+    <string name="setup_name_hint">Name (optional)</string>
+    <string name="setup_username_hint">Username</string>
+    <string name="setup_password_hint">Password</string>
+    <string name="setup_advanced">Advanced</string>
+    <string name="setup_internal_url_hint">Local (LAN) URL (optional)</string>
+    <string name="setup_internal_url_helper">Used automatically when you\'re on your home Wi-Fi.</string>
+    <string name="setup_test">Test connection</string>
+    <string name="setup_save">Save and connect</string>
+    <string name="setup_testing">Testing connection…</string>
+    <string name="setup_test_ok">Connection successful</string>
+    <string name="setup_docs_url">https://github.com/sfortis/phylax#readme</string>
     <string name="mute_groups_title">Mute notifications</string>
     <string name="mute_active_section">Active mutes</string>
     <string name="mute_cameras_section">Cameras</string>

--- a/app/src/main/res/xml/prefs_advanced.xml
+++ b/app/src/main/res/xml/prefs_advanced.xml
@@ -9,23 +9,4 @@
         android:summary="Route Frigate audio through the voice-call path. Many devices then apply hardware noise suppression and echo cancellation which can make speech clearer."
         android:defaultValue="false" />
 
-    <SwitchPreferenceCompat
-        android:key="use_custom_user_agent"
-        android:icon="@drawable/ic_adv_user_agent"
-        android:title="Use custom User Agent"
-        android:summary="Enable to set a custom browser User Agent string"
-        android:defaultValue="false" />
-
-    <EditTextPreference
-        android:key="custom_user_agent"
-        android:selectAllOnFocus="true"
-        android:singleLine="true"
-        android:title="Custom User Agent"
-        android:summary="Browser User Agent string to use"
-        android:defaultValue="Mozilla/5.0 (Linux; Android) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Mobile Safari/537.36"
-        android:inputType="text|textNoSuggestions"
-        android:importantForAutofill="no"
-        android:dependency="use_custom_user_agent"
-        app:iconSpaceReserved="true" />
-
 </PreferenceScreen>

--- a/fastlane/metadata/android/en-US/changelogs/16.txt
+++ b/fastlane/metadata/android/en-US/changelogs/16.txt
@@ -1,5 +1,3 @@
-# 2.8
-
 * New onboarding screen for first-time setup
 * Proper fullscreen handling for cameras
 * Improved landscape layout


### PR DESCRIPTION
Release 2.8 (versionCode 16).

## Changelog
* New onboarding screen for first-time setup
* Proper fullscreen handling for cameras
* Improved landscape layout
* Notifications now catch up on alerts missed while offline
* Fix: notification taps open the correct event

## Notes
* First-run gating removes the connect-before-configured error loop; permissions moved to feature boundaries.
* Camera fullscreen overlays the window decor (true edge-to-edge) with display-cutout insets in landscape.
* Version bumped to 2.8; WHATSNEW.md + F-Droid changelog (16.txt) updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)