### PR TITLE
Release 2.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Phylax makes your self-hosted Frigate NVR feel like a proper mobile app.
 - **Reliable push-style notifications** with snapshot thumbnails. Tap a notification and you land right on the event.
 - **Live system health at a glance.** CPU and GPU load in the top bar, tap for per-camera FPS and detector inference.
 - **Fine-grained notification filters** by camera, zone and severity. One notification per event, never a spam flood.
+- **Motion alerts per camera.** Movement with no recognised object, with its own sound and an optional urgent mode.
+- **Picture-in-Picture.** Pop a camera out into a floating window and keep watching while you use other apps.
 - **Mute cameras or groups on the fly.** Tap the bell in the toolbar to silence noisy cameras or whole zones without diving into Settings.
 - **Secure by default.** Supports client certificates (mTLS) for Cloudflare Access / nginx setups, self-signed certs on LAN.
 - **Two-way talk** on doorbell and intercom cameras, with the phone's call-quality audio path engaged for clearer voice.
@@ -116,15 +118,26 @@ The background `FrigateAlertService` keeps a `wss://.../ws` connection open and 
 - **Zone filter.** Reviews without matching zones are dropped for cameras where you've allow-listed zones.
 - **Reliable wake-up.** Alerts ring through Do Not Disturb at alarm volume even on Samsung One UI's vibrate ringer mode, routed via `STREAM_ALARM`. Music ducks (lowers volume briefly) instead of pausing.
 - **Custom bundled tones** (CC0) registered with MediaStore as **Phylax Alert** / **Phylax Chime** so they show up by name in the system sound picker — switchable from Settings → Notifications → Sounds.
+- **Only on external URL.** Turn notifications off automatically while you are on your home Wi-Fi.
+
+### Motion notifications
+
+Frigate publishes raw pixel motion per camera on the same socket, which fires even when no object is recognised. Opt in per camera under **Settings → Notifications → Motion (no object)**.
+
+- **Per-camera cooldown**, one minute by default.
+- **Its own sound**, picked separately from alerts and detections.
+- **Urgent mode** for a pop-up banner and stronger vibration.
+- **Tap opens the recording** at the moment the motion started.
+- Requires `detect` to be enabled for that camera in your Frigate config.
 
 ### Android 14+ reliability
 
 | Technique | Purpose |
 |---|---|
 | `FOREGROUND_SERVICE_TYPE_SPECIAL_USE` | Sidesteps the 6-hour cap imposed on `DATA_SYNC` foreground services |
-| Partial WakeLock | Keeps CPU scheduling the WebSocket ping loop during doze |
-| WifiLock (high-perf) | Prevents Wi-Fi radio power-save from dropping the socket |
+| Bounded wake lock | Held only while an incoming alert is handled, so it is posted before the CPU suspends |
 | Network callback kick | Forces a reconnect on network regain instead of waiting for exponential backoff |
+| 5-min revive alarm | Restarts the service and reconnects the socket if it is no longer live |
 | 15-min WorkManager watchdog | Revives the service if an OEM kills it (Samsung, MIUI, Honor) |
 | Repost-on-dismiss receiver | Restores the persistent notification within ~1 s if the user swipes it away |
 
@@ -163,6 +176,7 @@ The app registers the `frigate://` scheme.
 | `frigate://settings` | Settings root |
 | `frigate://review/<id>` | Specific review segment |
 | `frigate://event/<id>` | Specific event in Explore view |
+| `frigate://motion?camera=<name>&ts=<unixSeconds>` | Recording timeline at that moment |
 | `frigate://camera/<id>` | Specific camera (planned) |
 
 ## Permissions
@@ -178,7 +192,7 @@ Minimum viable set. Nothing else is requested.
 | `ACCESS_NOTIFICATION_POLICY` | Lets the alerts channel bypass Do Not Disturb (granted by you in System Settings, not on install) |
 | `FOREGROUND_SERVICE` + `FOREGROUND_SERVICE_SPECIAL_USE` | Alert listener lifetime |
 | `RECEIVE_BOOT_COMPLETED` | Re-start the listener after reboot |
-| `WAKE_LOCK` | Keep the WebSocket ping loop alive during doze |
+| `WAKE_LOCK` | Finish handling an incoming alert before the CPU suspends again |
 | `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` | Optional, prompted once on notification enable |
 | `REQUEST_INSTALL_PACKAGES` | In-app updater from GitHub releases |
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,8 +38,8 @@ android {
         applicationId = "com.asksakis.freegate"
         minSdk = 29
         targetSdk = 35
-        versionCode = 17
-        versionName = "2.9"
+        versionCode = 18
+        versionName = "2.10"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/asksakis/freegate/MainActivity.kt
+++ b/app/src/main/java/com/asksakis/freegate/MainActivity.kt
@@ -114,6 +114,10 @@ class MainActivity : AppCompatActivity(),
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
+        // Repairs installs where a dismissed certificate picker left the WebView refusing
+        // to ask for a client certificate again. No-op after the first run.
+        com.asksakis.freegate.utils.ClientCertManager.getInstance(this).clearStaleCertDecisionsOnce()
+
         setSupportActionBar(binding.toolbar)
         // Root destination shows the Phylax logo + stats badges + network
         // indicator + mute + settings; an extra app-name title text crowds

--- a/app/src/main/java/com/asksakis/freegate/auth/FrigateAuthManager.kt
+++ b/app/src/main/java/com/asksakis/freegate/auth/FrigateAuthManager.kt
@@ -34,6 +34,7 @@ class FrigateAuthManager private constructor(context: Context) {
     @Volatile private var cachedToken: String? = null
     @Volatile private var rawSetCookie: String? = null
     @Volatile private var tokenIssuedAtMs: Long = 0L
+    @Volatile private var lastLoginFailureMs: Long = 0L
 
     /**
      * Ensure a fresh token exists for [baseUrl]. Returns true on success. Forces a
@@ -53,13 +54,25 @@ class FrigateAuthManager private constructor(context: Context) {
             }
             mutex.withLock {
                 if (!force && isCurrentlyFresh()) return@withLock true
+                if (!force && isInFailureCooldown()) {
+                    // A deployment whose auth is done by a reverse proxy has no working
+                    // /api/login, so every caller would otherwise POST it again on its own
+                    // cadence: the stats poller alone retried twelve times a minute while
+                    // the app was open. The cooldown keeps one attempt per minute; anything
+                    // that genuinely warrants an immediate retry (a 401 from a consumer, a
+                    // profile swap, edited credentials) clears it via [invalidate].
+                    Log.d(TAG, "Login retry suppressed; previous attempt failed recently")
+                    return@withLock false
+                }
                 runCatching { performLogin(baseUrl) }
                     .onSuccess { token ->
                         cachedToken = token
                         tokenIssuedAtMs = System.currentTimeMillis()
+                        lastLoginFailureMs = 0L
                         installCookie(baseUrl, token)
                     }
                     .onFailure { e ->
+                        lastLoginFailureMs = System.currentTimeMillis()
                         Log.e(TAG, "Frigate login failed: ${e.message}")
                     }
                     .isSuccess
@@ -69,16 +82,28 @@ class FrigateAuthManager private constructor(context: Context) {
     /** Cookie header value for out-of-band HTTP/WS calls. Null if not logged in. */
     fun getCookieHeader(): String? = cachedToken?.let { "frigate_token=$it" }
 
-    /** Clear any cached token. The next consumer that needs auth will re-login. */
+    /**
+     * Clear any cached token. The next consumer that needs auth will re-login, without
+     * waiting out the failure cooldown: every caller of this reacts to something that
+     * makes an immediate retry meaningful (a 401 response, a profile swap, credentials
+     * the user just edited).
+     */
     fun invalidate() {
         cachedToken = null
         tokenIssuedAtMs = 0L
+        lastLoginFailureMs = 0L
     }
 
     private fun isCurrentlyFresh(): Boolean {
         if (cachedToken == null) return false
         val age = System.currentTimeMillis() - tokenIssuedAtMs
         return age < TOKEN_REFRESH_AFTER_MS
+    }
+
+    private fun isInFailureCooldown(): Boolean {
+        val since = lastLoginFailureMs
+        if (since == 0L) return false
+        return System.currentTimeMillis() - since < LOGIN_RETRY_COOLDOWN_MS
     }
 
     private fun performLogin(baseUrl: String): String {
@@ -140,6 +165,14 @@ class FrigateAuthManager private constructor(context: Context) {
 
         /** Refresh the token proactively once a day. Frigate defaults to 24h. */
         private val TOKEN_REFRESH_AFTER_MS = TimeUnit.HOURS.toMillis(20)
+
+        /**
+         * How long a failed login suppresses the next attempt. One minute matches the
+         * WebSocket's own reconnect backoff ceiling, so the listener still retries on
+         * roughly every reconnect cycle while high-frequency callers stop hammering an
+         * endpoint that has already refused them.
+         */
+        private val LOGIN_RETRY_COOLDOWN_MS = TimeUnit.MINUTES.toMillis(1)
 
         @Volatile
         private var INSTANCE: FrigateAuthManager? = null

--- a/app/src/main/java/com/asksakis/freegate/notifications/FrigateAlertService.kt
+++ b/app/src/main/java/com/asksakis/freegate/notifications/FrigateAlertService.kt
@@ -56,12 +56,13 @@ class FrigateAlertService : Service() {
     @Volatile private var lastStatusText: String = "Starting..."
     // Latest WS connection state, used by the periodic revive alarm to detect a socket
     // that died silently during Doze (now that no permanent wake lock keeps the ping loop
-    // alive) and reconnect it.
-    @Volatile private var wsConnected: Boolean = false
+    // alive) and reconnect it. Starts DISCONNECTED so the first health check may act.
+    @Volatile private var wsState: FrigateWsClient.State = FrigateWsClient.State.DISCONNECTED
 
     private var connectivityManager: ConnectivityManager? = null
     private var networkCallback: ConnectivityManager.NetworkCallback? = null
     @Volatile private var lastReconnectKickMs: Long = 0L
+    @Volatile private var networkCallbackRegisteredMs: Long = 0L
 
     /**
      * Restart the WebSocket whenever the base URL changes. Path matters — Frigate is
@@ -151,7 +152,7 @@ class FrigateAlertService : Service() {
             // ~5-min revive alarm (ServiceReviveReceiver), so use it as a periodic health
             // check: if the socket died silently in Doze, reconnect it. This replaces the
             // dead-socket detection the permanent wake lock used to give via the 60s ping.
-            if (!wsConnected) kickReconnect("periodic health check")
+            if (isSocketIdle()) kickReconnect("periodic health check")
             return START_STICKY
         }
         lastBaseUrl = baseUrl
@@ -252,9 +253,15 @@ class FrigateAlertService : Service() {
         val request = NetworkRequest.Builder().build()
         val callback = object : ConnectivityManager.NetworkCallback() {
             override fun onAvailable(network: Network) {
+                // Registering replays every network that is already up. That burst lands
+                // milliseconds after onCreate, while the service is opening its very first
+                // socket, so treating it as a transition would tear down the handshake and
+                // start another one. Only later callbacks are real changes.
+                if (System.currentTimeMillis() - networkCallbackRegisteredMs < REGISTRATION_SETTLE_MS) return
                 kickReconnect("network available")
             }
         }
+        networkCallbackRegisteredMs = System.currentTimeMillis()
         runCatching { cm.registerNetworkCallback(request, callback) }
             .onSuccess { networkCallback = callback }
             .onFailure { Log.w(TAG, "Failed to register network callback: ${it.message}") }
@@ -270,6 +277,20 @@ class FrigateAlertService : Service() {
         networkCallback = null
     }
 
+    /**
+     * True when no connection attempt is in flight, so a reconnect kick would help rather
+     * than interrupt. CONNECTING and RECONNECTING mean a handshake is running right now:
+     * the revive alarm fires every five minutes and used to tear those down mid-TLS,
+     * which cost a whole extra attempt on every service start.
+     */
+    private fun isSocketIdle(): Boolean = when (wsState) {
+        FrigateWsClient.State.DISCONNECTED, FrigateWsClient.State.AUTH_REQUIRED -> true
+        FrigateWsClient.State.CONNECTED,
+        FrigateWsClient.State.CONNECTING,
+        FrigateWsClient.State.RECONNECTING,
+        -> false
+    }
+
     private fun kickReconnect(reason: String) {
         val now = System.currentTimeMillis()
         if (now - lastReconnectKickMs < RECONNECT_KICK_THROTTLE_MS) return
@@ -282,17 +303,14 @@ class FrigateAlertService : Service() {
         wsClient.start(scope, url)
     }
 
-    private fun resolveBaseUrl(): String? {
-        val explicit = networkUtils.currentUrl.value
-        if (!explicit.isNullOrBlank()) return explicit.trimEnd('/')
-
-        // Fall back to whichever URL the user configured. Prefer internal for a background
-        // listener since that's typically reachable with lowest latency and no mTLS.
-        val internal = prefs.getString("internal_url", null)
-        if (!internal.isNullOrBlank()) return internal.trimEnd('/')
-        val external = prefs.getString("external_url", null)
-        return external?.trimEnd('/')
-    }
+    /**
+     * The listener regularly starts before [NetworkUtils] has resolved an endpoint (boot,
+     * OEM revive, app update), so it relies on that class's remembered choice rather than
+     * assuming the LAN URL. A phone that is usually away would otherwise open a socket to
+     * an unreachable host and get restarted by [urlObserver] moments later, costing an
+     * extra connection attempt and a login against the wrong server on every start.
+     */
+    private fun resolveBaseUrl(): String? = networkUtils.bestKnownBaseUrl()
 
     private fun tapAction(): FrigateNotifier.TapAction =
         if (prefs.getString("notify_tap_action", "review") == "home")
@@ -573,7 +591,7 @@ class FrigateAlertService : Service() {
 
         override fun onState(state: FrigateWsClient.State) {
             Log.d(TAG, "WS state: $state")
-            wsConnected = state == FrigateWsClient.State.CONNECTED
+            wsState = state
             val text = when (state) {
                 FrigateWsClient.State.CONNECTED -> "Listening for Frigate alerts"
                 FrigateWsClient.State.CONNECTING -> "Connecting..."
@@ -622,6 +640,9 @@ class FrigateAlertService : Service() {
         // Min interval between network-kick-driven WS restarts. Suppresses reconnect
         // storms when multiple transports flip up together (WiFi + cellular).
         private const val RECONNECT_KICK_THROTTLE_MS = 3_000L
+        // How long after registering the network callback its onAvailable calls are
+        // treated as the replay of already-connected networks rather than a transition.
+        private const val REGISTRATION_SETTLE_MS = 2_000L
 
         /** Epoch millis of the newest review we've seen — the reconnect catch-up watermark. */
         const val PREF_LAST_SEEN_REVIEW_TS = "notify_last_seen_review_ts"

--- a/app/src/main/java/com/asksakis/freegate/notifications/FrigateAlertService.kt
+++ b/app/src/main/java/com/asksakis/freegate/notifications/FrigateAlertService.kt
@@ -467,6 +467,7 @@ class FrigateAlertService : Service() {
             MotionSoundPlayer.play(this)
         }
 
+        val urgent = prefs.getBoolean(PREF_MOTION_URGENT, false)
         val nowSec = System.currentTimeMillis() / 1000L
         val baseUrl = lastBaseUrl
         if (baseUrl != null) {
@@ -474,10 +475,10 @@ class FrigateAlertService : Service() {
             // transient image error never eats the alert.
             scope.launch {
                 val bitmap = snapshotDownloader.download(baseUrl, "/api/$camera/latest.jpg")
-                notifier.notifyMotion(camera, nowSec, bitmap)
+                notifier.notifyMotion(camera, nowSec, bitmap, urgent)
             }
         } else {
-            notifier.notifyMotion(camera, nowSec)
+            notifier.notifyMotion(camera, nowSec, urgent = urgent)
         }
     }
 
@@ -630,6 +631,7 @@ class FrigateAlertService : Service() {
         // Per-camera motion notifications: opt-in camera set + per-camera cooldown (sec).
         const val PREF_MOTION_CAMERAS = "motion_notify_cameras"
         const val PREF_MOTION_COOLDOWN = "motion_notify_cooldown"
+        const val PREF_MOTION_URGENT = "motion_notify_urgent"
         // Reconnect catch-up guards (see runReviewCatchup). Throttle stops reconnect
         // storms from re-fetching; the notification cap prevents a flood after a long
         // offline stretch; the lookback bounds how far back a stale watermark reaches.

--- a/app/src/main/java/com/asksakis/freegate/notifications/FrigateConfigFetcher.kt
+++ b/app/src/main/java/com/asksakis/freegate/notifications/FrigateConfigFetcher.kt
@@ -59,9 +59,12 @@ class FrigateConfigFetcher(context: Context) {
      */
     private suspend fun fetchConfigBody(baseUrl: String): String? =
         withContext(Dispatchers.IO) {
+            // Same reasoning as the WebSocket and the snapshot fetch: a failed login
+            // still leaves /api/config reachable on deployments that authenticate in a
+            // reverse proxy or run without auth, so the request goes out regardless and
+            // the non-2xx branch below reports a server that really does refuse us.
             if (!authManager.ensureLoggedIn(baseUrl)) {
-                Log.w(TAG, "Login failed; can't fetch config")
-                return@withContext null
+                Log.d(TAG, "No session; fetching config without a cookie")
             }
             val cookie = authManager.getCookieHeader()
             val client = OkHttpClientFactory.build(baseUrl, clientCertManager)

--- a/app/src/main/java/com/asksakis/freegate/notifications/FrigateNotifier.kt
+++ b/app/src/main/java/com/asksakis/freegate/notifications/FrigateNotifier.kt
@@ -134,8 +134,17 @@ class FrigateNotifier(private val context: Context) {
      * id, labels or zones, so this is intentionally minimal: a headline plus the time,
      * an optional snapshot, and a tap that opens the app home (there is no review to deep
      * link to). Throttling / per-camera opt-in are enforced upstream by the service.
+     *
+     * [urgent] routes through the high-importance motion channel (heads-up + strong
+     * vibration, matching the alerts channel) for users whose motion cameras stand in for
+     * event alerts; otherwise the default motion channel (quiet, no heads-up) is used.
      */
-    fun notifyMotion(camera: String, timeSec: Long, snapshot: android.graphics.Bitmap? = null) {
+    fun notifyMotion(
+        camera: String,
+        timeSec: Long,
+        snapshot: android.graphics.Bitmap? = null,
+        urgent: Boolean = false,
+    ) {
         val title = "Motion detected on ${prettifyCameraName(camera)}"
         val body = "Motion • ${formatClockTime(timeSec.toDouble())}"
 
@@ -153,12 +162,18 @@ class FrigateNotifier(private val context: Context) {
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
         )
 
-        val builder = NotificationCompat.Builder(context, CHANNEL_MOTION)
+        val builder = NotificationCompat.Builder(
+            context,
+            if (urgent) CHANNEL_MOTION_URGENT else CHANNEL_MOTION,
+        )
             .setContentTitle(title)
             .setContentText(body)
             .setSmallIcon(R.drawable.ic_menu_camera)
-            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
-            .setCategory(NotificationCompat.CATEGORY_EVENT)
+            .setPriority(
+                if (urgent) NotificationCompat.PRIORITY_HIGH
+                else NotificationCompat.PRIORITY_DEFAULT,
+            )
+            .setCategory(if (urgent) NotificationCompat.CATEGORY_ALARM else NotificationCompat.CATEGORY_EVENT)
             .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
             .setAutoCancel(true)
             .setContentIntent(pending)
@@ -332,6 +347,24 @@ class FrigateNotifier(private val context: Context) {
                 setSound(null, null)
             },
         )
+        // Urgent variant: same heads-up + strong vibration + DND bypass as the alerts
+        // channel, for users whose motion cameras replace event alerts. Separate channel
+        // because channel importance is frozen at first creation, so it can't be toggled
+        // on the default motion channel. Chosen via the `motion_notify_urgent` pref.
+        mgr.createNotificationChannel(
+            NotificationChannel(
+                CHANNEL_MOTION_URGENT,
+                "Frigate motion (urgent)",
+                NotificationManager.IMPORTANCE_HIGH,
+            ).apply {
+                description = "Per-camera motion, urgent (heads-up + strong vibration)"
+                enableVibration(true)
+                vibrationPattern = longArrayOf(0, 250, 150, 250)
+                lockscreenVisibility = Notification.VISIBILITY_PUBLIC
+                setSound(null, null)
+                setBypassDnd(true)
+            },
+        )
         mgr.createNotificationChannel(
             NotificationChannel(
                 CHANNEL_STATUS,
@@ -371,6 +404,7 @@ class FrigateNotifier(private val context: Context) {
         const val CHANNEL_DETECTIONS = "frigate_detections_v2"
         private const val LEGACY_CHANNEL_DETECTIONS = "frigate_detections"
         const val CHANNEL_MOTION = "frigate_motion"
+        const val CHANNEL_MOTION_URGENT = "frigate_motion_urgent"
         private const val CHANNEL_STATUS = "frigate_status"
         private const val REQUEST_STATUS = 1_000
         private const val REQUEST_STATUS_DELETE = 1_001

--- a/app/src/main/java/com/asksakis/freegate/notifications/FrigateWsClient.kt
+++ b/app/src/main/java/com/asksakis/freegate/notifications/FrigateWsClient.kt
@@ -77,8 +77,8 @@ class FrigateWsClient(
         socket = null
     }
 
-    @Suppress("LoopWithTooManyJumpStatements") // two continues mirror two distinct retry
-    // paths (login failure vs handshake auth failure); splitting would hurt readability
+    @Suppress("LoopWithTooManyJumpStatements") // the continue retries the handshake after a
+    // forced re-login, the return ends the loop for good on repeated auth failures
     private suspend fun runLoop(baseUrl: String) {
         var attempt = 0
         var reauthRetried = false
@@ -86,10 +86,16 @@ class FrigateWsClient(
         while (true) {
             listener.onState(if (attempt == 0) State.CONNECTING else State.RECONNECTING)
 
+            // A failed login must never block the handshake. Frigate is routinely deployed
+            // with its own auth disabled and the authentication done by a reverse proxy
+            // (mTLS with injected user/group headers), or served straight from the
+            // unauthenticated port 5000. Those deployments have no working `/api/login`, so
+            // gating the socket on a successful login left the listener retrying forever
+            // while the WebView UI worked fine (issue #20). Connect without a cookie
+            // instead: a server that genuinely requires auth answers 401 on the handshake,
+            // which the AuthFailed branch below already surfaces as AUTH_REQUIRED.
             if (!authManager.ensureLoggedIn(baseUrl)) {
-                Log.w(TAG, "No session; waiting before retry")
-                delay(backoffMs(++attempt))
-                continue
+                Log.w(TAG, "Login failed; attempting handshake without a session cookie")
             }
 
             val wsUrl = wsUrlFor(baseUrl)

--- a/app/src/main/java/com/asksakis/freegate/notifications/ReviewCatchupFetcher.kt
+++ b/app/src/main/java/com/asksakis/freegate/notifications/ReviewCatchupFetcher.kt
@@ -34,9 +34,12 @@ class ReviewCatchupFetcher(context: Context) {
      */
     suspend fun fetchSince(baseUrl: String, sinceSec: Double): List<JSONObject> =
         withContext(Dispatchers.IO) {
+            // A failed login is not a reason to skip the fetch: setups that authenticate
+            // in a reverse proxy, or run Frigate with auth disabled, have no working
+            // /api/login yet answer /api/review without a cookie. A server that does
+            // require auth returns 401 and the non-2xx path below yields an empty list.
             if (!authManager.ensureLoggedIn(baseUrl)) {
-                Log.w(TAG, "Login failed; skipping catch-up fetch")
-                return@withContext emptyList()
+                Log.d(TAG, "No session; running catch-up fetch without a cookie")
             }
             val cookie = authManager.getCookieHeader()
             val client = OkHttpClientFactory.build(

--- a/app/src/main/java/com/asksakis/freegate/notifications/SnapshotDownloader.kt
+++ b/app/src/main/java/com/asksakis/freegate/notifications/SnapshotDownloader.kt
@@ -23,13 +23,17 @@ class SnapshotDownloader(context: Context) {
 
     suspend fun download(baseUrl: String, path: String): Bitmap? =
         withContext(Dispatchers.IO) {
-            // ensureLoggedIn returns true even when no credentials are configured
-            // (no-auth Frigate); getCookieHeader is null in that case. Fire the
-            // request without a Cookie header — Frigate without auth still
-            // serves /api/events/<id>/thumbnail.jpg. Without this guard removal
-            // the notification snapshots would silently fail on unauthenticated
-            // setups even though the WS and config calls work.
-            if (!authManager.ensureLoggedIn(baseUrl)) return@withContext null
+            // The request goes out whether or not a session could be established.
+            // ensureLoggedIn returns true when no credentials are configured (no-auth
+            // Frigate) and false when a login was attempted but failed, which is the
+            // normal case for a deployment whose auth is done by a reverse proxy and
+            // that has no working /api/login. Both serve
+            // /api/events/<id>/thumbnail.jpg without a cookie, so a failed login must
+            // not cost the notification its image. A server that really needs auth
+            // answers 401 and the non-2xx branch below handles it.
+            if (!authManager.ensureLoggedIn(baseUrl)) {
+                Log.d(TAG, "No session; fetching snapshot without a cookie")
+            }
             val cookie = authManager.getCookieHeader()
             val url = "${baseUrl.trimEnd('/')}${if (path.startsWith('/')) path else "/$path"}"
             val req = Request.Builder()

--- a/app/src/main/java/com/asksakis/freegate/stats/UiStatsWatcher.kt
+++ b/app/src/main/java/com/asksakis/freegate/stats/UiStatsWatcher.kt
@@ -92,14 +92,8 @@ class UiStatsWatcher(private val context: Context) {
         }
     }
 
-    private fun resolveBaseUrl(): String? {
-        val live = NetworkUtils.getInstance(context).currentUrl.value
-        if (!live.isNullOrBlank()) return live.trimEnd('/')
-        val prefs = PreferenceManager.getDefaultSharedPreferences(context)
-        val internal = prefs.getString("internal_url", null)?.trimEnd('/')
-        if (!internal.isNullOrBlank()) return internal
-        return prefs.getString("external_url", null)?.trimEnd('/')
-    }
+    private fun resolveBaseUrl(): String? =
+        NetworkUtils.getInstance(context).bestKnownBaseUrl()
 
     companion object {
         private const val TAG = "UiStatsWatcher"

--- a/app/src/main/java/com/asksakis/freegate/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/asksakis/freegate/ui/home/HomeFragment.kt
@@ -2188,24 +2188,30 @@ class HomeFragment : Fragment() {
     }
 
     /**
-     * Prompt user to pick a new client cert, then provide it to the request
-     * (or cancel the request if the user declined).
+     * Prompt user to pick a new client cert, then provide it to the request.
+     *
+     * Every path that fails to produce a certificate calls [ClientCertRequest.ignore]
+     * rather than `cancel`. Cancelling makes the WebView remember the refusal for that
+     * host and port and never raise the request again, which outlives the app process:
+     * one dismissed picker would permanently stop the certificate from being presented,
+     * however many times the user picks a valid one afterwards. Ignoring fails only the
+     * load in front of us and leaves the next attempt free to ask again.
      */
     private fun promptForNewCertificate(request: ClientCertRequest?) {
         val act = activity
         if (act == null) {
             Log.e(TAG, "Activity not available for certificate selection")
-            request?.cancel()
+            request?.ignore()
             return
         }
         clientCertManager.promptForCertificate(act, request) { alias ->
             if (alias != null) {
                 clientCertManager.provideCertificate(request, alias) { failedRequest ->
-                    act.runOnUiThread { failedRequest?.cancel() }
+                    act.runOnUiThread { failedRequest?.ignore() }
                 }
             } else {
                 Log.w(TAG, "No certificate selected")
-                request?.cancel()
+                request?.ignore()
             }
         }
     }

--- a/app/src/main/java/com/asksakis/freegate/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/asksakis/freegate/ui/home/HomeFragment.kt
@@ -585,12 +585,7 @@ class HomeFragment : Fragment() {
         currentLoadedUrl = url
     }
 
-    private fun resolveBaseUrlForLogin(): String? {
-        networkUtils.currentUrl.value?.takeIf { it.isNotBlank() }?.let { return it.trimEnd('/') }
-        val prefs = PreferenceManager.getDefaultSharedPreferences(requireContext())
-        return (prefs.getString("internal_url", null) ?: prefs.getString("external_url", null))
-            ?.trimEnd('/')
-    }
+    private fun resolveBaseUrlForLogin(): String? = networkUtils.bestKnownBaseUrl()
     
     private var lastRequestedUrl: String? = null
     private var networkValidationInProgress = false

--- a/app/src/main/java/com/asksakis/freegate/ui/settings/ConnectionSettingsFragment.kt
+++ b/app/src/main/java/com/asksakis/freegate/ui/settings/ConnectionSettingsFragment.kt
@@ -31,6 +31,7 @@ import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.PreferenceManager
 import com.asksakis.freegate.R
 import com.asksakis.freegate.auth.CredentialsStore
+import com.asksakis.freegate.auth.FrigateAuthManager
 import com.asksakis.freegate.auth.ServerProfileStore
 import com.asksakis.freegate.utils.ClientCertManager
 import com.asksakis.freegate.utils.NetworkUtils
@@ -204,6 +205,7 @@ class ConnectionSettingsFragment : PreferenceFragmentCompat() {
                         },
                         setter = { newValue ->
                             CredentialsStore.getInstance(requireContext()).setUsername(newValue)
+                            invalidateSession()
                             refreshPreferenceSummaries()
                         },
                     )
@@ -220,6 +222,7 @@ class ConnectionSettingsFragment : PreferenceFragmentCompat() {
                         },
                         setter = { newValue ->
                             CredentialsStore.getInstance(requireContext()).setPassword(newValue)
+                            invalidateSession()
                             refreshPreferenceSummaries()
                         },
                     )
@@ -233,6 +236,17 @@ class ConnectionSettingsFragment : PreferenceFragmentCompat() {
     /** Force the preference list to re-bind so SummaryProvider runs again. */
     private fun refreshPreferenceSummaries() {
         view?.post { listView?.adapter?.notifyDataSetChanged() }
+    }
+
+    /**
+     * Drop the cached Frigate session after the user edits their credentials. Without
+     * this the manager keeps serving the token it obtained with the old ones for up to
+     * twenty hours, so corrected credentials appear to do nothing until the process is
+     * restarted. It also clears the failed-login cooldown, letting the very next call
+     * try the new credentials immediately.
+     */
+    private fun invalidateSession() {
+        FrigateAuthManager.getInstance(requireContext()).invalidate()
     }
 
     private fun showAccountFieldDialog(

--- a/app/src/main/java/com/asksakis/freegate/utils/ClientCertManager.kt
+++ b/app/src/main/java/com/asksakis/freegate/utils/ClientCertManager.kt
@@ -2,9 +2,12 @@ package com.asksakis.freegate.utils
 
 import android.app.Activity
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
 import android.security.KeyChain
 import android.util.Log
 import android.webkit.ClientCertRequest
+import android.webkit.WebView
 import androidx.preference.PreferenceManager
 import java.net.Socket
 import java.security.Principal
@@ -38,6 +41,7 @@ class ClientCertManager private constructor(context: Context) {
             .apply()
         // Drop cached OkHttp clients so the next call picks up the new mTLS key manager.
         OkHttpClientFactory.invalidate()
+        clearWebViewCertDecisions()
     }
 
     fun clearAlias() {
@@ -46,6 +50,39 @@ class ClientCertManager private constructor(context: Context) {
             .remove(PREF_CLIENT_CERT_ALIAS)
             .apply()
         OkHttpClientFactory.invalidate()
+        clearWebViewCertDecisions()
+    }
+
+    /**
+     * Forget the per-host "do not send a client certificate" decisions the WebView stores
+     * whenever a certificate request is cancelled. Those decisions survive restarts and
+     * suppress [android.webkit.WebViewClient.onReceivedClientCertRequest] entirely, so a
+     * user who once dismissed the picker is never asked again: the certificate they later
+     * choose is never presented and the server reports no client certificate at all.
+     * Called whenever the saved alias changes, which is the point where the previous
+     * decision stops reflecting what the user wants.
+     */
+    private fun clearWebViewCertDecisions() {
+        // Must run on the UI thread; callers reach this from KeyChain callbacks and
+        // background threads.
+        Handler(Looper.getMainLooper()).post {
+            runCatching { WebView.clearClientCertPreferences(null) }
+                .onFailure { Log.w(TAG, "Could not clear WebView cert decisions: ${it.message}") }
+        }
+    }
+
+    /**
+     * One-shot repair for installs that were already stuck before the WebView decisions
+     * started being cleared on every alias change. Those users have a saved certificate
+     * that the WebView refuses to ask for, and no way to recover short of clearing app
+     * data, so drop the stored decisions once and record that it happened.
+     */
+    fun clearStaleCertDecisionsOnce() {
+        val prefs = PreferenceManager.getDefaultSharedPreferences(appContext)
+        if (prefs.getBoolean(PREF_CERT_DECISIONS_RESET, false)) return
+        prefs.edit().putBoolean(PREF_CERT_DECISIONS_RESET, true).apply()
+        Log.i(TAG, "Clearing stored WebView client-cert decisions once after upgrade")
+        clearWebViewCertDecisions()
     }
 
     /**
@@ -145,6 +182,8 @@ class ClientCertManager private constructor(context: Context) {
     companion object {
         private const val TAG = "ClientCertManager"
         const val PREF_CLIENT_CERT_ALIAS = "client_cert_alias"
+        /** Set once [clearStaleCertDecisionsOnce] has run, so it never repeats. */
+        private const val PREF_CERT_DECISIONS_RESET = "client_cert_decisions_reset"
 
         @Volatile
         private var INSTANCE: ClientCertManager? = null

--- a/app/src/main/java/com/asksakis/freegate/utils/NetworkUtils.kt
+++ b/app/src/main/java/com/asksakis/freegate/utils/NetworkUtils.kt
@@ -48,6 +48,13 @@ class NetworkUtils private constructor(private val context: Context) {
         // caller burst but short enough to feel instant to the user.
         private const val FORCE_REFRESH_DEBOUNCE_MS = 100L
 
+        /**
+         * The endpoint this resolver published last, kept so a background consumer that
+         * starts before the first resolution has a better guess than the raw internal
+         * URL. Consumers must check it still matches a configured server before using it.
+         */
+        const val PREF_LAST_ENDPOINT_URL = "last_resolved_endpoint_url"
+
 
         @Volatile
         private var INSTANCE: NetworkUtils? = null
@@ -691,12 +698,37 @@ class NetworkUtils private constructor(private val context: Context) {
     }
     
     /**
+     * The best Frigate base URL available right now, for callers that cannot wait for the
+     * asynchronous resolution behind [currentUrl] to produce its first value.
+     *
+     * Order: the resolved endpoint, then the endpoint resolved most recently in an earlier
+     * process, then the configured internal URL, then the external one. The remembered
+     * value is honoured only while it still matches a configured server, so an edited URL
+     * or a profile swap cannot send a caller to a host that no longer exists. Returns null
+     * when no server is configured.
+     */
+    fun bestKnownBaseUrl(): String? {
+        _currentUrl.value?.takeIf { it.isNotBlank() }?.let { return it.trimEnd('/') }
+
+        val internal = prefs.getString("internal_url", null)?.trimEnd('/')?.takeIf { it.isNotBlank() }
+        val external = prefs.getString("external_url", null)?.trimEnd('/')?.takeIf { it.isNotBlank() }
+        val remembered = prefs.getString(PREF_LAST_ENDPOINT_URL, null)?.trimEnd('/')
+        if (remembered != null && (remembered == internal || remembered == external)) return remembered
+        return internal ?: external
+    }
+
+    /**
      * Publish [url] on [currentUrl] only if it differs from the last value. Prevents
      * observers from re-running expensive work (WebView reloads, HTTP validation)
      * every time the network callback fires for a state that didn't actually change.
      */
     private fun emitEndpoint(url: String, internal: Boolean) {
         isInternalUrl = internal
+        // Remember the choice across process death. The alert service starts before this
+        // resolver has an answer (boot, OEM revive, app update) and would otherwise guess
+        // the LAN URL for a phone that is usually away, opening a socket to an unreachable
+        // host and tearing it down again seconds later. See resolveBaseUrl there.
+        prefs.edit().putString(PREF_LAST_ENDPOINT_URL, url).apply()
         val resolved = ResolvedEndpoint(url, internal)
         if (_endpoint.value != resolved) {
             _endpoint.postValue(resolved)

--- a/app/src/main/res/xml/prefs_notifications.xml
+++ b/app/src/main/res/xml/prefs_notifications.xml
@@ -66,6 +66,14 @@
             android:dependency="notifications_enabled"
             app:useSimpleSummaryProvider="true" />
 
+        <SwitchPreferenceCompat
+            android:key="motion_notify_urgent"
+            android:icon="@drawable/ic_notif_alert"
+            android:title="Urgent motion alerts"
+            android:summary="Pop up on screen with strong vibration, like event alerts"
+            android:defaultValue="false"
+            android:dependency="notifications_enabled" />
+
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/fastlane/metadata/android/en-US/changelogs/18.txt
+++ b/fastlane/metadata/android/en-US/changelogs/18.txt
@@ -1,5 +1,3 @@
-# 2.10
-
 * Alerts arrive again when a reverse proxy handles the sign-in, or when your Frigate has no login at all
 * Client certificates are offered again if the certificate prompt was ever dismissed
 * Motion notifications can be marked urgent, so they pop up with a stronger vibration


### PR DESCRIPTION
Fixes notifications behind reverse-proxy auth (#20) and client certificates that stopped being presented after a dismissed picker (#22). Adds an urgent channel for motion notifications and cuts the alert listener from three connection attempts on startup to one.