### PR TITLE
Bug fix: Audio Ducking Not Released After Alert/Notification Sound

### DIFF
--- a/app/src/main/java/com/asksakis/freegate/notifications/AlarmSoundPlayer.kt
+++ b/app/src/main/java/com/asksakis/freegate/notifications/AlarmSoundPlayer.kt
@@ -50,22 +50,21 @@ object AlarmSoundPlayer {
      */
     fun play(context: Context) {
         synchronized(lock) {
-            val audioManager =
-                context.getSystemService(Context.AUDIO_SERVICE) as? AudioManager
-            // Stop the previous player AND release its focus before we kick off
-            // a new playback — otherwise a fast second alert would leave the
-            // first alert's audio focus request orphaned. stopLocked alone
-            // doesn't release focus because it has no AudioManager handle.
+            // FORCE the use of applicationContext to pin the token identifier instance
+            val appContext = context.applicationContext
+            val audioManager = appContext.getSystemService(Context.AUDIO_SERVICE) as? AudioManager
+
             stopLocked()
             audioManager?.let(::releaseAudioFocus)
-            val choice = readUserChoice(context) ?: run {
-                Log.d(TAG, "Alert sound muted by user (Settings → Notifications → Sounds)")
+
+            val choice = readUserChoice(appContext) ?: run {
+                Log.d(TAG, "Alert sound muted by user")
                 return
             }
             if (audioManager == null) return
             try {
                 acquireAudioFocus(audioManager)
-                startPlayback(context.applicationContext, choice)
+                startPlayback(appContext, choice)
             } catch (e: Exception) {
                 Log.w(TAG, "Alarm playback failed: ${e.message}")
                 stopLocked()
@@ -176,7 +175,8 @@ object AlarmSoundPlayer {
     private fun stop(context: Context) {
         synchronized(lock) {
             stopLocked()
-            (context.getSystemService(Context.AUDIO_SERVICE) as? AudioManager)
+            // FORCE applicationContext here as well to match the acquisition hash exactly
+            (context.applicationContext.getSystemService(Context.AUDIO_SERVICE) as? AudioManager)
                 ?.let(::releaseAudioFocus)
         }
     }


### PR DESCRIPTION
An audio focus ducking leak was caused by a Context mismatch when resolving the system AudioManager instance.

When requesting focus, an Activity or standard component context was utilized, generating a specific client binder ID token. However, during the teardown pathway inside stop(), a different context layer was passed, generating a mismatched client ID token (see before log below). Because the abandonment token hash didn't match the original request token hash, the Android system's MediaFocusControl rejected the release request, leaving background audio streams (such as music players) permanently ducked at 0.2 volume.
Forcing both pathways to resolve the AudioManager via context.applicationContext pins the binder token hash, allowing the focus stack to clear cleanly (see after log below)

Before, note different hash vals for AudioManager:
```
09-03 14:39:53:338 requestAudioFocus() from uid/pid 10549/26034 AA=USAGE_ALARM/CONTENT_TYPE_SONIFICATION clientId=android.media.AudioManager@49db816 callingPack=com.asksakis.freegate req=3 flags=0x0 sdk=35
09-03 14:39:55:760 abandonAudioFocus() from uid/pid 10549/26034 clientId=android.media.AudioManager@94410a1 callingPack=com.asksakis.freegate
```

After, note AudioManager hash now identical in both calls:
```
09-03 14:56:09:036 requestAudioFocus() from uid/pid 10549/30121 AA=USAGE_ALARM/CONTENT_TYPE_SONIFICATION clientId=android.media.AudioManager@bd6fe1e callingPack=com.asksakis.freegate req=3 flags=0x0 sdk=35
09-03 14:56:11:562 abandonAudioFocus() from uid/pid 10549/30121 clientId=android.media.AudioManager@bd6fe1e callingPack=com.asksakis.freegate
```