### PR TITLE
Release 2.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ _This app is an unofficial third-party client and is not affiliated with the Fri
 ## Table of Contents
 
 - [What it does](#what-it-does)
+- [What's new](#whats-new)
 - [Screenshots](#screenshots)
 - [Install](#install)
 - [Verifying a download](#verifying-a-download)
@@ -62,6 +63,21 @@ Phylax makes your self-hosted Frigate NVR feel like a proper mobile app.
 - **Two-way talk** on doorbell and intercom cameras, with the phone's call-quality audio path engaged for clearer voice.
 - **Guided first-run setup.** Add your Frigate server in a couple of taps; runtime permissions are requested only when a feature needs them.
 - **Fullscreen and landscape viewing.** Open a camera edge-to-edge (notch-aware), with more of the screen given to video in landscape.
+
+## What's new
+
+<!-- Updated from WHATSNEW.md in the release preparation commit, alongside the version bump. -->
+
+Version 2.11:
+
+* Music and podcasts return to full volume after an alert or detection sound
+* Alerts keep working when you sign in on Frigate's own login page instead of in Settings
+* Share debug logs straight from Settings, About, with session tokens stripped out
+* Fixed a crash that could follow an app update while notifications were running
+* Holding a text field to paste no longer draws a grey box over the dialog
+* The signing key is published in the README, so you can verify a download yourself
+
+Every release is listed on the [Releases page](https://github.com/sfortis/phylax/releases).
 
 ## Screenshots
 
@@ -96,7 +112,7 @@ Every APK is signed with the same key, whether it came from F-Droid, Obtainium o
 Releases page. To check a file before you install it:
 
 ```
-apksigner verify --print-certs phylax-2.10.apk
+apksigner verify --print-certs phylax-v2.11.apk
 ```
 
 The certificate fingerprint must be:

--- a/README.md
+++ b/README.md
@@ -68,14 +68,9 @@ Phylax makes your self-hosted Frigate NVR feel like a proper mobile app.
 
 <!-- Updated from WHATSNEW.md in the release preparation commit, alongside the version bump. -->
 
-Version 2.11:
+Version 2.12:
 
-* Music and podcasts return to full volume after an alert or detection sound
-* Alerts keep working when you sign in on Frigate's own login page instead of in Settings
-* Share debug logs straight from Settings, About, with session tokens stripped out
-* Fixed a crash that could follow an app update while notifications were running
-* Holding a text field to paste no longer draws a grey box over the dialog
-* The signing key is published in the README, so you can verify a download yourself
+* Notifications with a client certificate recover on their own when the certificate was not readable yet as the app started
 
 Every release is listed on the [Releases page](https://github.com/sfortis/phylax/releases).
 
@@ -112,7 +107,7 @@ Every APK is signed with the same key, whether it came from F-Droid, Obtainium o
 Releases page. To check a file before you install it:
 
 ```
-apksigner verify --print-certs phylax-v2.11.apk
+apksigner verify --print-certs phylax-v2.12.apk
 ```
 
 The certificate fingerprint must be:

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,8 +38,8 @@ android {
         applicationId = "com.asksakis.freegate"
         minSdk = 29
         targetSdk = 35
-        versionCode = 19
-        versionName = "2.11"
+        versionCode = 20
+        versionName = "2.12"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/asksakis/freegate/utils/ClientCertManager.kt
+++ b/app/src/main/java/com/asksakis/freegate/utils/ClientCertManager.kt
@@ -153,8 +153,16 @@ class ClientCertManager private constructor(context: Context) {
     fun buildKeyManagers(): Array<KeyManager>? {
         val alias = getSavedAlias() ?: return null
         return try {
-            val privateKey: PrivateKey = KeyChain.getPrivateKey(appContext, alias) ?: return null
-            val chain: Array<X509Certificate> = KeyChain.getCertificateChain(appContext, alias) ?: return null
+            // Each miss below is reported separately. Silence here reads in a log exactly
+            // like "no certificate configured", which is the one case that is not a fault.
+            val privateKey: PrivateKey = KeyChain.getPrivateKey(appContext, alias) ?: run {
+                Log.w(TAG, "KeyChain holds no private key for '$alias' right now")
+                return null
+            }
+            val chain: Array<X509Certificate> = KeyChain.getCertificateChain(appContext, alias) ?: run {
+                Log.w(TAG, "KeyChain holds no certificate chain for '$alias' right now")
+                return null
+            }
 
             val km = object : X509KeyManager {
                 override fun getClientAliases(keyType: String?, issuers: Array<out Principal>?) = arrayOf(alias)
@@ -174,7 +182,7 @@ class ClientCertManager private constructor(context: Context) {
             }
             arrayOf(km)
         } catch (e: Exception) {
-            Log.w(TAG, "Failed to load client certificate: ${e.message}")
+            Log.w(TAG, "Could not load client certificate '$alias': ${e.message}")
             null
         }
     }

--- a/app/src/main/java/com/asksakis/freegate/utils/OkHttpClientFactory.kt
+++ b/app/src/main/java/com/asksakis/freegate/utils/OkHttpClientFactory.kt
@@ -2,6 +2,7 @@ package com.asksakis.freegate.utils
 
 import android.content.Context
 import android.util.Base64
+import android.util.Log
 import androidx.preference.PreferenceManager
 import com.asksakis.freegate.auth.CredentialsStore
 import okhttp3.HttpUrl
@@ -33,6 +34,8 @@ import javax.net.ssl.X509TrustManager
  */
 object OkHttpClientFactory {
 
+    private const val TAG = "OkHttpClientFactory"
+
     data class Timeouts(
         val connectSeconds: Long = 15,
         val readSeconds: Long = 15,
@@ -60,9 +63,8 @@ object OkHttpClientFactory {
                 .getBoolean("strict_tls_external", false)
         val permissiveTls = !(effectiveStrict && !UrlUtils.isPrivateIpUrl(baseUrl))
         val certAlias = clientCertManager.getSavedAlias()
-        val base = cache.computeIfAbsent(CacheKey(permissiveTls, certAlias)) {
-            buildBase(it, clientCertManager)
-        }
+        val key = CacheKey(permissiveTls, certAlias)
+        val base = cache[key] ?: buildAndMaybeCache(key, certAlias, clientCertManager)
 
         val builder = base.newBuilder()
             .connectTimeout(timeouts.connectSeconds, TimeUnit.SECONDS)
@@ -78,9 +80,40 @@ object OkHttpClientFactory {
         cache.clear()
     }
 
-    private fun buildBase(key: CacheKey, clientCertManager: ClientCertManager): OkHttpClient {
-        val builder = OkHttpClient.Builder()
+    /**
+     * Build the base client for [key] and cache it, unless it is not the client the user
+     * configured.
+     *
+     * A saved certificate alias whose key will not load right now yields a client with no
+     * client certificate at all. KeyChain refuses while the device is still locked after a
+     * reboot, which is exactly when the boot receiver and the revive alarm start the
+     * listener. Caching that client would hand it to every later call in this process, so
+     * mTLS would stay broken long after the key became readable, while the camera view kept
+     * working because the WebView asks KeyChain again on every request. Leaving it uncached
+     * costs one KeyChain lookup per call for as long as the failure lasts, and none once it
+     * succeeds.
+     */
+    private fun buildAndMaybeCache(
+        key: CacheKey,
+        certAlias: String?,
+        clientCertManager: ClientCertManager,
+    ): OkHttpClient {
         val keyManagers = clientCertManager.buildKeyManagers()
+        val client = buildBase(key, keyManagers, clientCertManager)
+        if (certAlias == null || keyManagers != null) {
+            cache[key] = client
+        } else {
+            Log.w(TAG, "Client certificate '$certAlias' is configured but unavailable; not caching this client")
+        }
+        return client
+    }
+
+    private fun buildBase(
+        key: CacheKey,
+        keyManagers: Array<javax.net.ssl.KeyManager>?,
+        clientCertManager: ClientCertManager,
+    ): OkHttpClient {
+        val builder = OkHttpClient.Builder()
 
         if (key.permissiveTls) {
             val trustAll = arrayOf<X509TrustManager>(TrustAllManager)

--- a/fastlane/metadata/android/en-US/changelogs/20.txt
+++ b/fastlane/metadata/android/en-US/changelogs/20.txt
@@ -1,3 +1,1 @@
-# 2.12
-
 * Notifications with a client certificate recover on their own when the certificate was not readable yet as the app started


### PR DESCRIPTION
Stops the app caching a connection built without the configured client certificate. KeyChain refuses while the device is still locked after a reboot, and the certificate-less client was then reused for the rest of the process, which reads as "mTLS works in the app but notifications do not".

Also reports which part of the certificate failed to load, so a shared log can tell a missing certificate apart from one that could not be read.