### PR TITLE
Release 2.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,14 @@ Phylax makes your self-hosted Frigate NVR feel like a proper mobile app.
 
 <!-- Updated from WHATSNEW.md in the release preparation commit, alongside the version bump. -->
 
-Version 2.12:
+Version 2.13:
 
-* Notifications with a client certificate recover on their own when the certificate was not readable yet as the app started
+* Turning on notifications now asks for the permissions it needs one at a time, instead of stacking dialogs on top of each other
+* Alert notifications come back on their own after the app updates, not only after a reboot
+* The background health check that restarts a dropped listener can no longer be refused by Android
+* Frigate served under a base path, for example /frigate, now loads
+* The reliability settings show whether alarms and reminders are granted, and the Do Not Disturb row opens the system list on Phylax
+* Shared debug logs record only the session cookie's attributes, never its value
 
 Every release is listed on the [Releases page](https://github.com/sfortis/phylax/releases).
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,8 +38,8 @@ android {
         applicationId = "com.asksakis.freegate"
         minSdk = 29
         targetSdk = 35
-        versionCode = 20
-        versionName = "2.12"
+        versionCode = 21
+        versionName = "2.13"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -58,6 +58,16 @@
          otherwise OEM doze/standby kills the foreground service unpredictably. -->
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 
+    <!--
+        Exact alarms are what let the revive alarm restart the listener. An alarm that fires
+        exactly puts the app on the system's temporary allowlist, and only then is a
+        foreground service allowed to start from the background. Android 14 and later grant
+        this permission automatically to apps the user has exempted from battery
+        optimisation, which the notification setup already asks for; where it is denied the
+        alarm falls back to the inexact variant and the revive can still be refused.
+    -->
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+
     <application
         android:name=".FrigateViewerApp"
         android:allowBackup="true"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -136,7 +136,16 @@
             android:permission="android.permission.RECEIVE_BOOT_COMPLETED">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
-                <action android:name="android.intent.action.LOCKED_BOOT_COMPLETED" />
+                <!--
+                    An app update stops the service and nothing brings it back until the user
+                    opens the app, because a background start is refused for an app that is
+                    not exempt from battery optimisation. This broadcast is one of the
+                    exemptions, so the listener returns on its own after an update.
+                    LOCKED_BOOT_COMPLETED is deliberately absent: it only reaches a
+                    directBootAware receiver, and at that point the encrypted storage that
+                    holds the settings is not readable anyway.
+                -->
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
             </intent-filter>
         </receiver>
 

--- a/app/src/main/java/com/asksakis/freegate/auth/FrigateAuthManager.kt
+++ b/app/src/main/java/com/asksakis/freegate/auth/FrigateAuthManager.kt
@@ -192,7 +192,11 @@ class FrigateAuthManager private constructor(context: Context) {
         val cookieLine = rawSetCookie ?: "frigate_token=$token; Path=/"
         cm.setCookie(baseUrl, cookieLine)
         cm.flush()
-        Log.d(TAG, "Installed frigate_token into WebView CookieManager for $baseUrl (raw=${cookieLine.take(80)}…)")
+        // The attributes are what mattered when a re-emitted cookie was rejected, so they
+        // stay. The value never appears: this line reaches shared log bundles, and a session
+        // token is the one thing in them that could let someone in.
+        val attributes = cookieLine.substringAfter(';', "").trim().ifEmpty { "none" }
+        Log.d(TAG, "Installed frigate_token for $baseUrl (attributes: $attributes)")
     }
 
     companion object {

--- a/app/src/main/java/com/asksakis/freegate/notifications/FrigateBootReceiver.kt
+++ b/app/src/main/java/com/asksakis/freegate/notifications/FrigateBootReceiver.kt
@@ -7,14 +7,17 @@ import android.util.Log
 import androidx.preference.PreferenceManager
 
 /**
- * Restarts [FrigateAlertService] after device boot, but only when the user actually
- * has notifications enabled. Gating here (not at manifest level) means the receiver
- * does literally nothing when the feature is off — no service start, no wake locks.
+ * Restarts [FrigateAlertService] after device boot and after the app is updated, but only
+ * when the user actually has notifications enabled. Gating here rather than in the manifest
+ * means the receiver does literally nothing when the feature is off, with no service start
+ * and no wake locks.
  */
 class FrigateBootReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent?) {
+        // Both actions are exemptions from the background foreground-service restriction,
+        // which is what makes starting the listener from here legal at all.
         if (intent?.action != Intent.ACTION_BOOT_COMPLETED &&
-            intent?.action != Intent.ACTION_LOCKED_BOOT_COMPLETED
+            intent?.action != Intent.ACTION_MY_PACKAGE_REPLACED
         ) return
         val notificationsEnabled = PreferenceManager.getDefaultSharedPreferences(context)
             .getBoolean("notifications_enabled", false)
@@ -22,7 +25,7 @@ class FrigateBootReceiver : BroadcastReceiver() {
             Log.d(TAG, "Boot received but notifications disabled; skipping service start")
             return
         }
-        Log.d(TAG, "Boot received, starting FrigateAlertService")
+        Log.d(TAG, "${intent.action} received, starting FrigateAlertService")
         FrigateAlertService.updateForContext(context)
     }
 

--- a/app/src/main/java/com/asksakis/freegate/notifications/ServiceReviveReceiver.kt
+++ b/app/src/main/java/com/asksakis/freegate/notifications/ServiceReviveReceiver.kt
@@ -42,11 +42,20 @@ class ServiceReviveReceiver : BroadcastReceiver() {
             val flags = PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
             val pi = PendingIntent.getBroadcast(context, REQUEST_CODE, intent, flags)
             val trigger = System.currentTimeMillis() + delayMs
+            // Exact matters here for a reason that has nothing to do with timing accuracy.
+            // A firing exact alarm puts the app on the system's temporary allowlist, which
+            // is what permits the receiver to start the foreground service. The inexact
+            // variant wakes the device and grants nothing, so Android refuses the start and
+            // the revive is lost (see FrigateAlertService.updateForContext). The user can
+            // deny the permission, so the inexact call stays as the fallback.
+            val exactAllowed = Build.VERSION.SDK_INT < Build.VERSION_CODES.S ||
+                am.canScheduleExactAlarms()
             runCatching {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                    am.setAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, trigger, pi)
+                if (exactAllowed) {
+                    am.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, trigger, pi)
                 } else {
-                    am.set(AlarmManager.RTC_WAKEUP, trigger, pi)
+                    Log.w(TAG, "Exact alarms not permitted; the revive may be refused")
+                    am.setAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, trigger, pi)
                 }
             }.onFailure { Log.w(TAG, "Could not schedule alarm: ${it.message}") }
         }

--- a/app/src/main/java/com/asksakis/freegate/ui/NotificationOnboarding.kt
+++ b/app/src/main/java/com/asksakis/freegate/ui/NotificationOnboarding.kt
@@ -1,0 +1,249 @@
+package com.asksakis.freegate.ui
+
+import android.app.NotificationManager
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.provider.Settings
+import android.widget.Toast
+import androidx.fragment.app.Fragment
+import androidx.preference.PreferenceManager
+import com.asksakis.freegate.notifications.BatteryOptHelper
+import com.asksakis.freegate.notifications.OemSettingsIntents
+
+/**
+ * The reliability grants the background alert listener needs, asked one at a time.
+ *
+ * Turning alerts on is only the first of several permissions, and the rest live on three
+ * different system screens. Asking for them in one pass stacked modal dialogs on top of
+ * each other and left the most important one at the bottom, so this walks the user through
+ * them in the order they matter and pauses whenever a step hands the user to the system.
+ *
+ * Both places that can turn alerts on share this class, so they cannot drift apart on which
+ * grants they ask for. The POST_NOTIFICATIONS request itself stays with the host, because an
+ * ActivityResultLauncher has to be registered by the fragment that owns it.
+ *
+ * [includeDnd] is false for the first-run offer on Home. Do Not Disturb access is not needed
+ * for alerts to arrive, only for them to ring while Do Not Disturb is on, so the first-run
+ * sequence leaves it to the dedicated row in Settings.
+ */
+class NotificationOnboarding(
+    private val fragment: Fragment,
+    private val includeDnd: Boolean,
+) {
+    private enum class Step { BATTERY, OEM, DND }
+
+    private val pending = mutableListOf<Step>()
+
+    /** True while the user is on a system screen that one of the steps opened. */
+    private var waitingForSystemScreen = false
+
+    private val prefs
+        get() = fragment.context?.let { PreferenceManager.getDefaultSharedPreferences(it) }
+
+    /**
+     * Queue every step the user has not already answered and show the first one that still
+     * applies. Each step carries its own flag, so turning alerts off and on again does not
+     * walk the user back through prompts they have answered.
+     */
+    fun start() {
+        val prefs = prefs ?: return
+        pending.clear()
+        if (!prefs.getBoolean(PREF_BATTERY_PROMPTED, false)) {
+            pending += Step.BATTERY
+        }
+        if (OemSettingsIntents.hasCustomBackgroundSettings() &&
+            !prefs.getBoolean(PREF_OEM_PROMPTED, false)
+        ) {
+            pending += Step.OEM
+        }
+        if (includeDnd) {
+            pending += Step.DND
+        }
+        runNext()
+    }
+
+    /** Drop a queued walkthrough, for a host that has decided alerts stay off after all. */
+    fun cancel() {
+        pending.clear()
+    }
+
+    /**
+     * Continue a walkthrough that is waiting for the user to come back from a system screen.
+     * Hosts call this from their own `onResume`, which is what keeps the next prompt from
+     * being created behind that screen.
+     */
+    fun onResume() {
+        if (!waitingForSystemScreen) return
+        waitingForSystemScreen = false
+        runNext()
+    }
+
+    /**
+     * Show the next queued step that still applies. A step whose grant is already in place
+     * shows nothing and reports back false, so the walkthrough moves on without a dead
+     * dialog rather than stopping there.
+     */
+    private fun runNext() {
+        if (waitingForSystemScreen) return
+        while (pending.isNotEmpty()) {
+            val shown = when (pending.removeAt(0)) {
+                Step.BATTERY -> promptBatteryOptimization(autoPrompt = true, onDismiss = ::runNext)
+                Step.OEM -> promptOemBackgroundRestrictions(onDismiss = ::runNext)
+                Step.DND -> promptDndAccess(autoPrompt = true, onDismiss = ::runNext)
+            }
+            if (shown) return
+        }
+    }
+
+    /**
+     * Offer the battery-optimisation exemption, which is what stops Android killing the
+     * listener in the background. Returns false when the exemption is already in place.
+     *
+     * [autoPrompt] is true inside the walkthrough and false when the user taps the Settings
+     * row, which only changes the wording: the row tap needs no explanation of why.
+     */
+    fun promptBatteryOptimization(
+        autoPrompt: Boolean,
+        onDismiss: (() -> Unit)? = null,
+    ): Boolean {
+        val ctx = fragment.context ?: return false
+        if (BatteryOptHelper.isIgnoringOptimizations(ctx)) {
+            markPrompted(PREF_BATTERY_PROMPTED)
+            // The exemption alone is not enough on Samsung, MIUI or ColorOS. Inside the
+            // walkthrough the OEM tip is a step of its own, so only a standalone call
+            // chains to it from here.
+            if (autoPrompt && onDismiss == null &&
+                OemSettingsIntents.hasCustomBackgroundSettings()
+            ) {
+                promptOemBackgroundRestrictions()
+            }
+            return false
+        }
+        FreegateDialogs.builder(ctx)
+            .setTitle("Keep notifications reliable")
+            .setMessage(
+                if (autoPrompt)
+                    "Android may silently kill the background listener after a while. " +
+                        "Allow Phylax to bypass battery optimization so alerts arrive " +
+                        "reliably?"
+                else
+                    "Allow Phylax to bypass battery optimization?"
+            )
+            .setPositiveButton("Allow") { _, _ ->
+                if (onDismiss != null) waitingForSystemScreen = true
+                markPrompted(PREF_BATTERY_PROMPTED)
+                BatteryOptHelper.requestIgnore(ctx)
+                if (onDismiss == null && OemSettingsIntents.hasCustomBackgroundSettings()) {
+                    promptOemBackgroundRestrictions()
+                }
+            }
+            .setNegativeButton("Not now") { _, _ -> markPrompted(PREF_BATTERY_PROMPTED) }
+            .apply { onDismiss?.let { resume -> setOnDismissListener { resume() } } }
+            .show()
+        return true
+    }
+
+    /**
+     * Show the OEM background-restrictions instructions for this manufacturer. Only queued
+     * on devices that have such a screen, so it always shows and always returns true.
+     */
+    fun promptOemBackgroundRestrictions(onDismiss: (() -> Unit)? = null): Boolean {
+        val ctx = fragment.context ?: return false
+        markPrompted(PREF_OEM_PROMPTED)
+        val oem = OemSettingsIntents.current()
+        FreegateDialogs.builder(ctx)
+            .setTitle("One more step on ${oem.displayName}")
+            .setMessage(OemSettingsIntents.instructionsFor(oem))
+            .setPositiveButton("Open settings") { _, _ ->
+                if (onDismiss != null) waitingForSystemScreen = true
+                OemSettingsIntents.openBackgroundRestrictions(ctx)
+            }
+            .setNegativeButton("Later", null)
+            .apply { onDismiss?.let { resume -> setOnDismissListener { resume() } } }
+            .show()
+        return true
+    }
+
+    /**
+     * Offer Do Not Disturb access, which is what lets the alert channel ring at alarm volume
+     * while Do Not Disturb is on. Returns false when access is already granted, and when
+     * [autoPrompt] is true and the user has already been asked once.
+     */
+    fun promptDndAccess(
+        autoPrompt: Boolean,
+        onDismiss: (() -> Unit)? = null,
+    ): Boolean {
+        val ctx = fragment.context ?: return false
+        val nm = ctx.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        if (nm.isNotificationPolicyAccessGranted) return false
+        if (autoPrompt && prefs?.getBoolean(PREF_DND_PROMPTED, false) == true) return false
+
+        FreegateDialogs.builder(ctx)
+            .setTitle("Override Do Not Disturb")
+            .setMessage(
+                if (autoPrompt)
+                    "Phylax can ring alerts at alarm volume even while Do Not " +
+                        "Disturb is on, so you don't miss a real event overnight. " +
+                        "Android opens a list of every app that can ask for this, so find " +
+                        "Phylax there and turn it on."
+                else
+                    "Grant Phylax permission to override Do Not Disturb so alerts " +
+                        "ring at alarm volume? Android opens a list of every app that " +
+                        "can ask for this, so find Phylax there and turn it on."
+            )
+            .setPositiveButton("Open settings") { _, _ ->
+                markPrompted(PREF_DND_PROMPTED)
+                if (onDismiss != null) waitingForSystemScreen = true
+                openDndAccessSettings()
+            }
+            .setNegativeButton("Not now") { _, _ -> markPrompted(PREF_DND_PROMPTED) }
+            .apply { onDismiss?.let { resume -> setOnDismissListener { resume() } } }
+            .show()
+        return true
+    }
+
+    /**
+     * Open the Do Not Disturb access list with this app's row scrolled to and highlighted.
+     *
+     * There is no public per-app screen for this permission, only the list of every app that
+     * has asked for it. The two extras below are the long-standing AOSP Settings convention
+     * for pointing a list screen at one row, and a Settings build that does not understand
+     * them shows the plain list instead.
+     */
+    fun openDndAccessSettings() {
+        val ctx = fragment.context ?: return
+        val pkg = ctx.packageName
+        val intent = Intent(Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS).apply {
+            putExtra(SETTINGS_ARG_KEY, pkg)
+            putExtra(
+                SETTINGS_SHOW_ARGS,
+                Bundle().apply { putString(SETTINGS_ARG_KEY, pkg) },
+            )
+        }
+        runCatching { fragment.startActivity(intent) }
+            .onFailure {
+                Toast.makeText(ctx, "Unable to open DND access settings", Toast.LENGTH_SHORT)
+                    .show()
+            }
+    }
+
+    private fun markPrompted(key: String) {
+        prefs?.edit()?.putBoolean(key, true)?.apply()
+    }
+
+    companion object {
+        /** Set once the battery-optimisation exemption has been offered, either answer. */
+        const val PREF_BATTERY_PROMPTED = "battery_opt_prompted"
+
+        /** Set once Do Not Disturb access has been offered, either answer. */
+        const val PREF_DND_PROMPTED = "dnd_prompted"
+
+        /** Set once the OEM background-restrictions tip has been shown. */
+        const val PREF_OEM_PROMPTED = "oem_reliability_prompted"
+
+        /** AOSP Settings extras that scroll a list screen to one row and highlight it. */
+        private const val SETTINGS_ARG_KEY = ":settings:fragment_args_key"
+        private const val SETTINGS_SHOW_ARGS = ":settings:show_fragment_args"
+    }
+}

--- a/app/src/main/java/com/asksakis/freegate/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/asksakis/freegate/ui/home/HomeFragment.kt
@@ -573,7 +573,27 @@ class HomeFragment : Fragment() {
             "$baseUrl/explore?event_id=${pending.eventId}"
         is com.asksakis.freegate.notifications.DeepLinkRouter.Target.MotionRecording ->
             "$baseUrl/review?timestamp=${pending.camera}_${pending.timestampSec}"
-        null -> baseUrl
+        null -> viewUrl(baseUrl)
+    }
+
+    /**
+     * The address to hand the web view for a plain server URL.
+     *
+     * A Frigate published under a base path, through `FRIGATE_BASE_PATH`, has to be opened
+     * with the trailing slash. Loaded from `https://host/frigate`, the browser resolves the
+     * page's relative asset links against `https://host/` and the interface never appears,
+     * while the API and the WebSocket keep working because those are built by appending to
+     * the trimmed URL (issue #31). The app strips trailing slashes everywhere, so a user
+     * cannot supply one themselves.
+     *
+     * A URL that already carries a query or a fragment is a page address rather than a
+     * server address, and is left exactly as it is.
+     */
+    private fun viewUrl(url: String): String {
+        val cut = url.indexOfFirst { it == '?' || it == '#' }
+        val path = if (cut < 0) url else url.substring(0, cut)
+        val rest = if (cut < 0) "" else url.substring(cut)
+        return if (path.endsWith("/")) url else "$path/$rest"
     }
 
     /** Nudge the URL observer so a staged URL actually loads after we unblock it. */
@@ -581,7 +601,7 @@ class HomeFragment : Fragment() {
         val url = networkUtils.currentUrl.value ?: return
         val web = _binding?.webView ?: return
         Log.d(TAG, "Fallback initial load: $url")
-        web.loadUrl(url)
+        web.loadUrl(viewUrl(url))
         currentLoadedUrl = url
     }
 
@@ -672,7 +692,7 @@ class HomeFragment : Fragment() {
             if (currentBase != null && currentBase == newBase && currentLoadedUrl != url) {
                 // Only the fragment changed — no reload.
                 Log.d(TAG, "Fragment-only change, navigating: $url")
-                binding.webView.loadUrl(url)
+                binding.webView.loadUrl(viewUrl(url))
                 currentLoadedEndpoint = resolved
                 return@observe
             }
@@ -685,9 +705,9 @@ class HomeFragment : Fragment() {
             // unaffected.
             val urlToLoad = if (currentLoadedUrl == null) {
                 com.asksakis.freegate.notifications.DeepLinkRouter.consumePending()
-                    ?.let { resolveDeepLinkTarget(url.trimEnd('/'), it) } ?: url
+                    ?.let { resolveDeepLinkTarget(url.trimEnd('/'), it) } ?: viewUrl(url)
             } else {
-                url
+                viewUrl(url)
             }
             if (urlToLoad != url) Log.d(TAG, "Initial load redirected to deep-link: $urlToLoad")
             loadUrlWithConnectivityCheck(urlToLoad)
@@ -724,7 +744,7 @@ class HomeFragment : Fragment() {
                     if (reloadOnValidationSuccess && !urlLoadInProgress && !target.isNullOrEmpty()) {
                         reloadOnValidationSuccess = false
                         Log.d(TAG, "Validation SUCCESS — triggering queued reload: $target")
-                        loadUrlWithConnectivityCheck(target)
+                        loadUrlWithConnectivityCheck(viewUrl(target))
                     }
                     // First successful connect right after adding a server: offer alerts.
                     maybeOfferNotifications()
@@ -1669,7 +1689,7 @@ class HomeFragment : Fragment() {
                     // Get current URL and reload directly (bypass debouncing)
                     val currentUrl = networkUtils.currentUrl.value
                     if (currentUrl != null) {
-                        safeBinding.webView.loadUrl(currentUrl)
+                        safeBinding.webView.loadUrl(viewUrl(currentUrl))
                         currentLoadedUrl = currentUrl
                     } else {
                         // Fallback to refreshing network status
@@ -1985,6 +2005,9 @@ class HomeFragment : Fragment() {
                     android.os.Handler(android.os.Looper.getMainLooper()).postDelayed({
                         // Check binding again after delay
                         if (_binding != null && isAdded) {
+                            // Reload the page that was showing, verbatim. This is a browsed
+                            // address such as /review, not a server entry, and a slash appended
+                            // here would change which document the browser asks for.
                             safeBinding.webView.loadUrl(currentLoadedUrl!!)
                         }
                     }, 100) // 100ms delay
@@ -2066,7 +2089,7 @@ class HomeFragment : Fragment() {
             // directly. If it requires auth, Frigate will redirect to /login
             // and the user can sign in from there.
             Log.d(TAG, "Loading new server (no creds path): $newUrl")
-            webView.loadUrl(newUrl)
+            webView.loadUrl(viewUrl(newUrl))
             currentLoadedUrl = newUrl
         }
     }

--- a/app/src/main/java/com/asksakis/freegate/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/asksakis/freegate/ui/home/HomeFragment.kt
@@ -61,6 +61,16 @@ class HomeFragment : Fragment() {
     /** Lazy RECORD_AUDIO request, fired the first time the page asks for the mic. */
     private lateinit var micPermissionLauncher: ActivityResultLauncher<String>
 
+    /**
+     * The reliability walkthrough that follows the one-time "enable alerts" offer. Do Not
+     * Disturb access is left out here: alerts arrive without it, and the first run is not
+     * the moment to ask for a permission the user has no reason for yet. The dedicated row
+     * in Settings, Notifications offers it.
+     */
+    private val notificationOnboarding by lazy {
+        com.asksakis.freegate.ui.NotificationOnboarding(this, includeDnd = false)
+    }
+
     /** POST_NOTIFICATIONS request for the one-time post-setup "enable alerts" offer. */
     private lateinit var notifPermissionLauncher: ActivityResultLauncher<String>
 
@@ -493,8 +503,9 @@ class HomeFragment : Fragment() {
     /**
      * Turn on Alert notifications and bring the listener service up. Alerts default on
      * and Detections stay off (the user opts into the noisier stream in Settings).
-     * Enabling straight from here deliberately skips the DND / battery-optimization
-     * prompts that Settings shows, keeping this a single, quiet action.
+     * The battery-optimisation exemption is offered right after, because the listener
+     * does not survive without it. Do Not Disturb access is left to the Settings screen,
+     * so enabling from here stays a short sequence.
      */
     private fun enableAlertNotifications() {
         if (!isAdded) return
@@ -507,38 +518,7 @@ class HomeFragment : Fragment() {
         com.asksakis.freegate.notifications.FrigateAlertService
             .updateForContext(requireContext(), forceRestart = true)
         Toast.makeText(context, "Alert notifications enabled", Toast.LENGTH_SHORT).show()
-        promptBatteryOptimizationForNotifications(prefs)
-    }
-
-    /**
-     * Notification-reliability boundary: Android can silently kill the background WS
-     * listener under battery optimization, so right after enabling alerts we offer the
-     * exemption. Reuses [BatteryOptHelper] and the same `battery_opt_prompted` flag as
-     * the Settings screen, so the user is never asked twice. DND access is intentionally
-     * left to Settings to keep this a single, light prompt.
-     */
-    private fun promptBatteryOptimizationForNotifications(
-        prefs: android.content.SharedPreferences,
-    ) {
-        val ctx = context ?: return
-        if (com.asksakis.freegate.notifications.BatteryOptHelper.isIgnoringOptimizations(ctx)) {
-            prefs.edit().putBoolean("battery_opt_prompted", true).apply()
-            return
-        }
-        com.asksakis.freegate.ui.FreegateDialogs.builder(ctx)
-            .setTitle("Keep notifications reliable")
-            .setMessage(
-                "Android may silently kill the background listener after a while. Allow " +
-                    "Phylax to bypass battery optimization so alerts arrive reliably?"
-            )
-            .setPositiveButton("Allow") { _, _ ->
-                com.asksakis.freegate.notifications.BatteryOptHelper.requestIgnore(ctx)
-                prefs.edit().putBoolean("battery_opt_prompted", true).apply()
-            }
-            .setNegativeButton("Not now") { _, _ ->
-                prefs.edit().putBoolean("battery_opt_prompted", true).apply()
-            }
-            .show()
+        notificationOnboarding.start()
     }
 
     /**
@@ -1959,6 +1939,8 @@ class HomeFragment : Fragment() {
         // This ensures any URL changes made in settings are applied
         homeViewModel.refreshStatus()
         applyAudioMode()
+        // Continue the reliability walkthrough if the user is back from a system screen.
+        notificationOnboarding.onResume()
         Log.d(TAG, "HomeFragment resumed - refreshing network status to get latest URL")
         reloadIfActiveServerChanged()
 

--- a/app/src/main/java/com/asksakis/freegate/ui/settings/NotificationsSettingsFragment.kt
+++ b/app/src/main/java/com/asksakis/freegate/ui/settings/NotificationsSettingsFragment.kt
@@ -1,11 +1,13 @@
 package com.asksakis.freegate.ui.settings
 
 import android.Manifest
+import android.app.AlarmManager
 import android.app.AlertDialog
 import android.app.NotificationManager
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
@@ -107,6 +109,7 @@ class NotificationsSettingsFragment : PreferenceFragmentCompat() {
 
         setupDndBypassPreference()
         setupBatteryOptimizationPreference()
+        setupExactAlarmPreference()
         setupOemBackgroundPreference()
         setupLastAlertPreference()
         setupDiagnosticsPreference()
@@ -123,6 +126,11 @@ class NotificationsSettingsFragment : PreferenceFragmentCompat() {
         refreshFilterSummaries()
         refreshLastAlertSummary()
         refreshDndBypassSummary()
+        // Both of these read a system permission that the user may have just changed on a
+        // settings screen. Re-running the setup rebinds the summary and the visibility; the
+        // delayed refresh at the tap site cannot know how long the user spent there.
+        setupBatteryOptimizationPreference()
+        setupExactAlarmPreference()
     }
 
     private fun refreshFilterSummaries() {
@@ -206,7 +214,10 @@ class NotificationsSettingsFragment : PreferenceFragmentCompat() {
     private fun setupDndBypassPreference() {
         val pref = findPreference<Preference>("dnd_bypass") ?: return
         pref.setOnPreferenceClickListener {
-            openDndAccessSettings()
+            // Through the dialog rather than straight to the system screen. Android has no
+            // per-app screen for this permission, only the list of every app that has asked
+            // for it, so the user needs to be told what to look for before they get there.
+            maybePromptDndAccess(autoPrompt = false)
             true
         }
         refreshDndBypassSummary()
@@ -230,10 +241,12 @@ class NotificationsSettingsFragment : PreferenceFragmentCompat() {
                 if (autoPrompt)
                     "Phylax can ring alerts at alarm volume even while Do Not " +
                         "Disturb is on, so you don't miss a real event overnight. " +
-                        "Grant Do Not Disturb access?"
+                        "Android opens a list of every app that can ask for this, so find " +
+                        "Phylax there and turn it on."
                 else
                     "Grant Phylax permission to override Do Not Disturb so alerts " +
-                        "ring at alarm volume?"
+                        "ring at alarm volume? Android opens a list of every app that " +
+                        "can ask for this, so find Phylax there and turn it on."
             )
             .setPositiveButton("Open settings") { _, _ ->
                 prefs?.edit()?.putBoolean("dnd_prompted", true)?.apply()
@@ -278,6 +291,38 @@ class NotificationsSettingsFragment : PreferenceFragmentCompat() {
         refresh()
         pref.setOnPreferenceClickListener {
             maybePromptBatteryOptimization(autoPrompt = false)
+            view?.postDelayed({ refresh() }, 1_500)
+            true
+        }
+    }
+
+    /**
+     * Exact alarms are what let the revive alarm restart the listener from the background,
+     * because a firing exact alarm puts the app on the system's temporary allowlist. Android
+     * grants the permission on its own to apps the user has exempted from battery
+     * optimisation, so this row appears only for the users who are still missing it, and it
+     * disappears once it is granted or once the exemption covers it.
+     */
+    private fun setupExactAlarmPreference() {
+        val pref = findPreference<Preference>("exact_alarms") ?: return
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+            pref.isVisible = false
+            return
+        }
+        fun refresh() {
+            val am = requireContext().getSystemService(Context.ALARM_SERVICE) as? AlarmManager
+            pref.isVisible = am?.canScheduleExactAlarms() == false
+        }
+        refresh()
+        pref.setOnPreferenceClickListener {
+            val intent = Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM)
+                .setData(Uri.parse("package:${requireContext().packageName}"))
+            runCatching { startActivity(intent) }
+                .onFailure {
+                    // Some OEM builds do not carry the per-app screen. The general settings
+                    // page is a worse landing spot but still gets the user there.
+                    runCatching { startActivity(Intent(Settings.ACTION_SETTINGS)) }
+                }
             view?.postDelayed({ refresh() }, 1_500)
             true
         }

--- a/app/src/main/java/com/asksakis/freegate/ui/settings/NotificationsSettingsFragment.kt
+++ b/app/src/main/java/com/asksakis/freegate/ui/settings/NotificationsSettingsFragment.kt
@@ -18,6 +18,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
+import androidx.preference.SwitchPreferenceCompat
 import com.asksakis.freegate.R
 import com.asksakis.freegate.auth.CredentialsStore
 import com.asksakis.freegate.notifications.AlarmSoundPlayer
@@ -31,6 +32,7 @@ import com.asksakis.freegate.notifications.MotionSoundPlayer
 import kotlinx.coroutines.Dispatchers
 import com.asksakis.freegate.notifications.OemSettingsIntents
 import com.asksakis.freegate.notifications.ServiceLifecycleLog
+import com.asksakis.freegate.ui.NotificationOnboarding
 import com.asksakis.freegate.utils.NetworkUtils
 import kotlinx.coroutines.launch
 
@@ -60,19 +62,20 @@ class NotificationsSettingsFragment : PreferenceFragmentCompat() {
             if (key == "notifications_enabled" &&
                 prefs.getBoolean("notifications_enabled", false)
             ) {
-                // Feature boundary: enabling alerts is when we ask for the notification
-                // permission (Android 13+). Without it, FrigateNotifier silently drops
-                // every alert - so request it here rather than at app launch.
-                maybeRequestNotificationPermission()
-                if (!prefs.getBoolean("battery_opt_prompted", false)) {
-                    maybePromptBatteryOptimization(autoPrompt = true)
-                }
-                // DND access is independent of battery optimisation: prompt
-                // unconditionally on first enable so the alarm-stream override
-                // can actually take effect.
-                maybePromptDndAccess(autoPrompt = true)
+                // Feature boundary: enabling alerts is when we ask for everything the
+                // background listener needs. Without POST_NOTIFICATIONS (Android 13+)
+                // FrigateNotifier silently drops every alert, so it is requested here
+                // rather than at app launch.
+                beginFirstEnableOnboarding()
             }
         }
+
+    /**
+     * The reliability walkthrough, shared with the first-run offer on Home so the two entry
+     * points ask for the same grants. This screen includes the Do Not Disturb step, which
+     * the first-run offer leaves out.
+     */
+    private val onboarding by lazy { NotificationOnboarding(this, includeDnd = true) }
 
     private val liveNotificationKeys = setOf(
         "notifications_enabled",
@@ -131,6 +134,7 @@ class NotificationsSettingsFragment : PreferenceFragmentCompat() {
         // delayed refresh at the tap site cannot know how long the user spent there.
         setupBatteryOptimizationPreference()
         setupExactAlarmPreference()
+        onboarding.onResume()
     }
 
     private fun refreshFilterSummaries() {
@@ -179,24 +183,39 @@ class NotificationsSettingsFragment : PreferenceFragmentCompat() {
     private val notificationPermissionLauncher = registerForActivityResult(
         ActivityResultContracts.RequestPermission()
     ) { granted ->
-        if (!granted) {
-            Toast.makeText(
-                requireContext(),
-                "Notifications permission denied - alerts won't appear",
-                Toast.LENGTH_LONG,
-            ).show()
+        if (granted) {
+            onboarding.start()
+            return@registerForActivityResult
         }
+        // Nothing the listener posts can reach the user without this permission, so the
+        // switch goes back off instead of advertising a feature that cannot work. Writing
+        // the preference back also stops the service, through the change listener above.
+        onboarding.cancel()
+        findPreference<SwitchPreferenceCompat>("notifications_enabled")?.isChecked = false
+        Toast.makeText(
+            requireContext(),
+            "Notifications permission denied, so alerts stay off",
+            Toast.LENGTH_LONG,
+        ).show()
     }
 
-    /** Ask for POST_NOTIFICATIONS on Android 13+ if it isn't already granted. */
-    private fun maybeRequestNotificationPermission() {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return
-        val granted = ContextCompat.checkSelfPermission(
-            requireContext(), Manifest.permission.POST_NOTIFICATIONS,
-        ) == PackageManager.PERMISSION_GRANTED
-        if (!granted) {
+    /**
+     * Ask for the notification permission, then hand over to [NotificationOnboarding] for
+     * the reliability grants. The permission goes first because without it nothing the
+     * listener posts can be shown at all.
+     */
+    private fun beginFirstEnableOnboarding() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            ContextCompat.checkSelfPermission(
+                requireContext(), Manifest.permission.POST_NOTIFICATIONS,
+            ) != PackageManager.PERMISSION_GRANTED
+        ) {
+            // Nothing else is worth asking for until this one is answered, so the launcher
+            // callback is what starts the rest of the walkthrough.
             notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+            return
         }
+        onboarding.start()
     }
 
     override fun onDestroy() {
@@ -214,66 +233,25 @@ class NotificationsSettingsFragment : PreferenceFragmentCompat() {
     private fun setupDndBypassPreference() {
         val pref = findPreference<Preference>("dnd_bypass") ?: return
         pref.setOnPreferenceClickListener {
-            // Through the dialog rather than straight to the system screen. Android has no
-            // per-app screen for this permission, only the list of every app that has asked
-            // for it, so the user needs to be told what to look for before they get there.
-            maybePromptDndAccess(autoPrompt = false)
+            val nm = requireContext()
+                .getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            if (nm.isNotificationPolicyAccessGranted) {
+                // Already granted, so the row is how the user reviews or withdraws it.
+                // Explaining how to grant something they have would be noise.
+                onboarding.openDndAccessSettings()
+            } else {
+                onboarding.promptDndAccess(autoPrompt = false)
+            }
             true
         }
         refreshDndBypassSummary()
-    }
-
-    /**
-     * Auto-prompt path triggered the first time the user enables notifications
-     * (or whenever they tap the dedicated DND row). Skips silently if access is
-     * already granted or if the user has dismissed the auto-prompt before.
-     */
-    private fun maybePromptDndAccess(autoPrompt: Boolean) {
-        val ctx = requireContext()
-        val nm = ctx.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        if (nm.isNotificationPolicyAccessGranted) return
-        val prefs = preferenceManager.sharedPreferences
-        if (autoPrompt && prefs?.getBoolean("dnd_prompted", false) == true) return
-
-        com.asksakis.freegate.ui.FreegateDialogs.builder(ctx)
-            .setTitle("Override Do Not Disturb")
-            .setMessage(
-                if (autoPrompt)
-                    "Phylax can ring alerts at alarm volume even while Do Not " +
-                        "Disturb is on, so you don't miss a real event overnight. " +
-                        "Android opens a list of every app that can ask for this, so find " +
-                        "Phylax there and turn it on."
-                else
-                    "Grant Phylax permission to override Do Not Disturb so alerts " +
-                        "ring at alarm volume? Android opens a list of every app that " +
-                        "can ask for this, so find Phylax there and turn it on."
-            )
-            .setPositiveButton("Open settings") { _, _ ->
-                prefs?.edit()?.putBoolean("dnd_prompted", true)?.apply()
-                openDndAccessSettings()
-            }
-            .setNegativeButton("Not now") { _, _ ->
-                prefs?.edit()?.putBoolean("dnd_prompted", true)?.apply()
-            }
-            .show()
-    }
-
-    private fun openDndAccessSettings() {
-        runCatching { startActivity(Intent(Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS)) }
-            .onFailure {
-                Toast.makeText(
-                    requireContext(),
-                    "Unable to open DND access settings",
-                    Toast.LENGTH_SHORT,
-                ).show()
-            }
     }
 
     private fun refreshDndBypassSummary() {
         val pref = findPreference<Preference>("dnd_bypass") ?: return
         val nm = requireContext().getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
         pref.summary = if (nm.isNotificationPolicyAccessGranted) {
-            "Granted — alerts ring at alarm volume even while DND is on."
+            "Granted. Alerts ring at alarm volume even while DND is on."
         } else {
             "Tap to grant Do Not Disturb access so alerts can override DND."
         }
@@ -283,14 +261,14 @@ class NotificationsSettingsFragment : PreferenceFragmentCompat() {
         val pref = findPreference<Preference>("battery_optimization") ?: return
         fun refresh() {
             pref.summary = if (BatteryOptHelper.isIgnoringOptimizations(requireContext())) {
-                "Exempted — the listener can run in the background."
+                "Exempted. The listener can run in the background."
             } else {
-                "Battery optimization is ON — the listener may be killed. Tap to exempt."
+                "Battery optimization is ON, so the listener may be killed. Tap to exempt."
             }
         }
         refresh()
         pref.setOnPreferenceClickListener {
-            maybePromptBatteryOptimization(autoPrompt = false)
+            onboarding.promptBatteryOptimization(autoPrompt = false)
             view?.postDelayed({ refresh() }, 1_500)
             true
         }
@@ -300,8 +278,9 @@ class NotificationsSettingsFragment : PreferenceFragmentCompat() {
      * Exact alarms are what let the revive alarm restart the listener from the background,
      * because a firing exact alarm puts the app on the system's temporary allowlist. Android
      * grants the permission on its own to apps the user has exempted from battery
-     * optimisation, so this row appears only for the users who are still missing it, and it
-     * disappears once it is granted or once the exemption covers it.
+     * optimisation, so most users will find it already granted. The row stays visible either
+     * way and reports the live state, like the two rows above it. It is hidden only below
+     * API 31, where the permission does not exist and there is no screen to open.
      */
     private fun setupExactAlarmPreference() {
         val pref = findPreference<Preference>("exact_alarms") ?: return
@@ -311,7 +290,12 @@ class NotificationsSettingsFragment : PreferenceFragmentCompat() {
         }
         fun refresh() {
             val am = requireContext().getSystemService(Context.ALARM_SERVICE) as? AlarmManager
-            pref.isVisible = am?.canScheduleExactAlarms() == false
+            pref.summary = if (am?.canScheduleExactAlarms() != false) {
+                "Granted. The five-minute check can restart the listener."
+            } else {
+                "Tap to allow alarms and reminders so the five-minute check can restart " +
+                    "the listener."
+            }
         }
         refresh()
         pref.setOnPreferenceClickListener {
@@ -326,55 +310,6 @@ class NotificationsSettingsFragment : PreferenceFragmentCompat() {
             view?.postDelayed({ refresh() }, 1_500)
             true
         }
-    }
-
-    private fun maybePromptBatteryOptimization(autoPrompt: Boolean) {
-        val ctx = requireContext()
-        if (BatteryOptHelper.isIgnoringOptimizations(ctx)) {
-            preferenceManager.sharedPreferences?.edit()
-                ?.putBoolean("battery_opt_prompted", true)?.apply()
-            // Still surface the OEM tip on first-enable devices — battery exemption
-            // alone isn't enough on Samsung / MIUI / ColorOS.
-            if (autoPrompt && OemSettingsIntents.hasCustomBackgroundSettings()) {
-                showOemReliabilityPrompt(ctx)
-            }
-            return
-        }
-
-        com.asksakis.freegate.ui.FreegateDialogs.builder(ctx)
-            .setTitle("Keep notifications reliable")
-            .setMessage(
-                if (autoPrompt)
-                    "Android may silently kill the background listener after a while. " +
-                        "Allow Phylax to bypass battery optimization so alerts arrive " +
-                        "reliably?"
-                else
-                    "Allow Phylax to bypass battery optimization?"
-            )
-            .setPositiveButton("Allow") { _, _ ->
-                BatteryOptHelper.requestIgnore(ctx)
-                preferenceManager.sharedPreferences?.edit()
-                    ?.putBoolean("battery_opt_prompted", true)?.apply()
-                // Chain to the OEM prompt — on Samsung et al, battery-opt exemption is
-                // only half the story.
-                if (OemSettingsIntents.hasCustomBackgroundSettings()) {
-                    showOemReliabilityPrompt(ctx)
-                }
-            }
-            .setNegativeButton("Not now", null)
-            .show()
-    }
-
-    private fun showOemReliabilityPrompt(ctx: android.content.Context) {
-        val oem = OemSettingsIntents.current()
-        com.asksakis.freegate.ui.FreegateDialogs.builder(ctx)
-            .setTitle("One more step on ${oem.displayName}")
-            .setMessage(OemSettingsIntents.instructionsFor(oem))
-            .setPositiveButton("Open settings") { _, _ ->
-                OemSettingsIntents.openBackgroundRestrictions(ctx)
-            }
-            .setNegativeButton("Later", null)
-            .show()
     }
 
     private fun setupZoneFilterPreference() {

--- a/app/src/main/res/xml/prefs_notifications.xml
+++ b/app/src/main/res/xml/prefs_notifications.xml
@@ -166,6 +166,13 @@
             android:dependency="notifications_enabled" />
 
         <Preference
+            android:key="exact_alarms"
+            android:icon="@drawable/ic_notif_battery"
+            android:title="Alarms and reminders"
+            android:summary="Lets the five-minute check restart the listener"
+            android:dependency="notifications_enabled" />
+
+        <Preference
             android:key="oem_background_restrictions"
             android:icon="@drawable/ic_notif_oem"
             android:title="Background restrictions"

--- a/fastlane/metadata/android/en-US/changelogs/21.txt
+++ b/fastlane/metadata/android/en-US/changelogs/21.txt
@@ -1,5 +1,3 @@
-# 2.13
-
 * Turning on notifications now asks for the permissions it needs one at a time, instead of stacking dialogs on top of each other
 * Alert notifications come back on their own after the app updates, not only after a reboot
 * The background health check that restarts a dropped listener can no longer be refused by Android


### PR DESCRIPTION
Turning on notifications used to fire the permission request and both reliability dialogs
at once, so the user met three modals stacked on top of each other with the most important
one at the bottom. The grants are now asked one at a time from a single shared walkthrough,
which both the first-run offer and the Settings switch use, so the two can no longer drift
apart on what they ask for. Denying the notification permission turns the switch back off
instead of leaving an enabled feature that cannot work.

Also fixes a Frigate served under a base path not loading (#31), the listener not returning
after an app update, and the five-minute health check being refused by Android because its
alarm was not exact.
